### PR TITLE
docs: MIT 许可证 + 贡献/安全指南

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,66 @@
+# 贡献指南
+
+欢迎给 atm 提 PR。这份指南只有两条是硬约束（见下「铁律」），其余都是让评审更快的建议。
+
+## 开发环境
+
+Linux 或 WSL2 + tmux（3.0+，开发基准 3.6）+ Python 3.11+。依赖管理统一用 [uv](https://docs.astral.sh/uv/)。
+
+```bash
+git clone https://github.com/lyfuci/ai-terminal-manager
+cd ai-terminal-manager/app
+uv sync                      # 建虚拟环境并安装 dev 依赖
+uv run pytest                # 全量测试
+uv run ruff check src tests  # lint
+uv run ruff format src tests # 格式化
+```
+
+装成本机命令：`uv tool install --editable .`（或 `uv tool install 'git+<仓库>#subdirectory=app'`）。
+
+## 铁律（不遵守的 PR 会被要求改）
+
+1. **会话数据只读**。atm 解析 `~/.claude/projects/` 和 `~/.codex/` 下的文件，这两个目录由
+   CLI 自己管理 —— 任何代码路径都不得写入、移动、删除或“整理”它们。测试只能用自建的
+   tmp_path fixture，绝不读取贡献者机器上的真实会话数据。
+2. **tmux 只走公开 CLI**。绝不读写 `/tmp/tmux-<uid>/*` 的 unix socket，也绝不解析控制模式
+   (`-CC`) 之外的上游私有协议。需要 tmux 的测试用临时 fixture，不用真 server。
+3. **索引层不依赖 tmux**。`src/atm/index.py` 及其下游（model / sources / cache / jsonl）刻意
+   保持可以在 tmux 之外运行，为将来的其他后端留路。别在这里 import `tmux.py`。
+4. **格式假设要防御**。两个 CLI 的 JSONL 是逆向观察出来的，不是公开契约。解析必须容忍
+   未知 type / 缺字段 / 脏行，绝不允许一条坏记录弄挂整个索引。
+
+## 写测试
+
+- 新功能先写测试（RED → GREEN → REFACTOR）；修 bug 先写一个能复现的失败测试再修。
+- tmux 输出解析类测试（如 `parse_panes`）是格式变更的第一道防线，改动输出格式时同步更新。
+- 涉及 tmux 真实行为（如 `swap-pane` 跨窗口、`split-window -f`）的结论，优先补一个
+  `experiments/<yyyy-mm-dd>-<tag>/` 下的隔离 socket 验证脚本，再在代码注释里引用它。
+
+## tmux 实验规则（在真机器上验证时）
+
+- 一律用隔离 socket：`tmux -L <名字> -f /dev/null`。**只 `-L` 不 `-f` 不够** —— 新 server
+  仍会 source `~/.tmux.conf`，带 `@continuum-restore on` 的环境会把用户整个存档恢复到你的
+  测试 server 里（实测发生过）。
+- 用完 `kill-server` 并删掉 socket 文件；不要用 `pkill -f tmux` 这类模式匹配清理。
+- 绝不碰用户的默认 server 或默认 socket。
+
+## 提交
+
+- 从最新 `main` 切分支；commit message 用 `feat:` / `fix:` / `docs:` / `test:` / `chore:` 前缀。
+- PR 请附：动机、改动摘要、验证方式（测试输出或实验记录）。
+- 新依赖需要理由 —— atm 刻意保持零运行时依赖（要在 `display-popup` 里反复冷启动），
+  标准库能解决就不加。
+
+## 想贡献但不知道从哪开始
+
+看看 issue 里的 `good first issue`；或者这些方向永远欢迎：
+
+- 新 CLI 的会话数据源适配（`src/atm/sources/` 加一个适配器）。
+- 现有解析对 CLI 新版本的兼容修复（尤其标题提取，见 `text.py` 的注入包装剥离）。
+- TUI 体验、终端宽度/东亚字符处理（`text.py`）。
+
+## 暂不接受的方向
+
+- 自写常驻 daemon / GUI（架构分岔口 A/B 未拍板，见根目录 README「未拍板的分岔口」）。
+- 读写 tmux 私有 wire protocol。
+- 任何把用户会话数据上传到网络的功能 —— atm 的边界是本机工具。

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 sean
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -226,3 +226,8 @@ Windows GUI / 控制模式解析器 / 布局同步全部蒸发。
   上半段列正在跑的格子（Claude Code 自己会把 pane 标题设成 `✳ <任务名>`，不用反查会话 id），
   下半段接历史；选中运行中的 → `swap-pane` 换进主格，选中历史 → 新 window 里 resume 再换进来。
   `prefix + b` 开/切/收，`prefix + B` 把当前格子收进 `bg`。推翻了「侧栏不做成 tmux pane」的旧结论（见上）。
+
+## 贡献
+
+欢迎 issue / PR。开发环境与约定见 [CONTRIBUTING.md](CONTRIBUTING.md)；
+安全问题不要开公开 issue，见 [SECURITY.md](SECURITY.md)。许可证 [MIT](LICENSE)。

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# 安全政策
+
+## 报告漏洞
+
+**不要为安全问题开公开 issue。** 用 GitHub 的
+[Private vulnerability reporting](https://github.com/lyfuci/ai-terminal-manager/security/advisories/new)，
+或在 issue 里只描述“有一类安全问题，希望私下沟通”。
+
+## 已知的安全边界
+
+- atm **只读**本机的 `~/.claude/projects/` 和 `~/.codex/`，从不写入、不联网。
+- 会话标题可能包含你对话里的文字，列表和 TUI 会原样显示 —— 注意别在共享屏幕时露出敏感标题。
+- 投递走 `tmux send-keys` + `shlex.quote`，但**忙闲检查挡不住 readline 缓冲区里已打了一半的
+  命令**（会先发 `C-e C-u` 清行，但这不是原子操作）。
+- 内存闸门依赖 systemd user slice；不可用时静默降级为不限内存。
+
+## 报告时请不要附上
+
+- 真实的会话转录或 JSONL 片段（标题和路径就可能含敏感信息）。
+- 会话 UUID、公司 / 内部项目名。

--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -3,6 +3,7 @@ name = "atm"
 version = "0.1.0"
 description = "AI Terminal Manager — 跨 agent 的统一会话历史，投递到指定 tmux pane"
 readme = "README.md"
+license = "MIT"
 requires-python = ">=3.11"
 # 刻意保持零运行时依赖：atm 要在 tmux display-popup 里被反复冷启动，
 # 任何 import 开销都会让「唤出侧栏」这个手势变卡。stdlib 够用。


### PR DESCRIPTION
## 内容

- **LICENSE**：MIT，版权行 `2026 sean`。
- **CONTRIBUTING.md**：开发环境（uv / pytest / ruff）、4 条铁律（会话数据只读、tmux 只走公开 CLI、索引层不依赖 tmux、格式防御）、tmux 实验的隔离 socket 规则、提交流程、欢迎/暂不接受的方向。
- **SECURITY.md**：安全问题走 GitHub Private vulnerability reporting，不要开公开 issue；明确不该贴会话转录 / UUID / 内部项目名。
- **app/pyproject.toml**：补 `license = "MIT"` 元数据。
- **README.md**：新增「贡献」一节链接三份文件。

## 验证

- [x] `uv run pytest`：210 passed
- [x] `uv run ruff check`：通过
- [x] `uv build`：带 license 元数据构建成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)