### PR TITLE
fix: tmux 绑定写 atm 的绝对路径，不写裸名

### DIFF
--- a/app/src/atm/install.py
+++ b/app/src/atm/install.py
@@ -2,8 +2,9 @@
 
 为什么不用 `run-shell /abs/path/atm.tmux`：那条路径指向源码目录，
 `app/` 一旦搬走或改名，用户的 tmux.conf 就悄悄失效了。
-直接写 `bind-key` 行是自包含的 —— 只要 `atm` 在 PATH 上就一直有效，
-而且用户能直接看懂和改。（`atm.tmux` 保留给 tpm 用户。）
+直接写 `bind-key` 行是自包含的，而且用户能直接看懂和改。
+（`atm.tmux` 保留给 tpm 用户。）绑定里调的是 `atm` 的绝对路径而不是裸名 ——
+tmux server 的 PATH 是它启动那刻的快照，见 `resolve_atm_command`。
 
 这个模块会**改用户的全局配置**，所以：
 - 用 marker 包起来，可精确识别 / 幂等 / 可干净卸载；
@@ -113,14 +114,21 @@ class InstallResult:
 
 
 def resolve_atm_command() -> str:
-    """决定 tmux 里该怎么调 atm。
+    """决定 tmux 里该怎么调 atm —— 永远是**绝对路径**。
 
-    优先 PATH 上的 `atm`（最快，实测 60ms）；找不到就退回当前解释器的 `-m atm`，
-    这样从源码树直接跑也能装。
+    优先 PATH 上的 `atm`，但写进 tmux.conf 的是 `which()` 解析出的完整路径，
+    不是裸名。因为 tmux server 用的是**启动它那一刻**的环境，而 `atm` 一般装在
+    `~/.local/bin`（uv tool / pipx）：只要 server 比那条 PATH 更早起来，
+    `run-shell 'atm …'` 就是 127，报错只有一行
+    `'atm sidebar --toggle --pane %1' returned 127`，非常难查。
+    安装时的 shell 找得到，不代表 tmux 找得到。
+
+    找不到就退回当前解释器的 `-m atm`（同样是绝对路径），这样从源码树直接跑也能装。
     """
-    if shutil.which("atm"):
-        return "atm"
-    return f"{sys.executable} -m atm"
+    found = shutil.which("atm")
+    if found:
+        return shlex.quote(found)
+    return f"{shlex.quote(sys.executable)} -m atm"
 
 
 def build_plan(

--- a/app/tests/test_install.py
+++ b/app/tests/test_install.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shlex
 from pathlib import Path
 
 from atm import install as install_mod
@@ -207,3 +208,47 @@ def test_sidebar_key_validation(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="不能相同"):
         _plan(conf, key="b", sidebar_key="b")
     assert {b.key for b in _plan(conf, sidebar_key="s").bindings} == {"a", "A", "s", "S"}
+
+
+def test_resolve_atm_command_returns_absolute_path(tmp_path: Path, monkeypatch) -> None:
+    """写进 tmux.conf 的必须是绝对路径，不能是裸名 `atm`。
+
+    tmux server 用的是**启动它那一刻**的环境。`atm` 常装在 `~/.local/bin`
+    （uv tool / pipx），如果 server 比这条 PATH 更早起来，`run-shell 'atm …'`
+    就是 127 command not found —— 实测发生过，报错只有一行
+    `'atm sidebar --toggle --pane %1' returned 127`，很难查。
+    安装时的 shell 找得到不代表 tmux 找得到，所以要把 which() 的结果原样写进去。
+    """
+    fake = tmp_path / ".local" / "bin" / "atm"
+    fake.parent.mkdir(parents=True)
+    fake.write_text("#!/bin/sh\n", encoding="utf-8")
+    fake.chmod(0o755)
+    monkeypatch.setattr(install_mod.shutil, "which", lambda _: str(fake))
+
+    assert install_mod.resolve_atm_command() == str(fake)
+
+
+def test_resolve_atm_command_quotes_paths_with_spaces(tmp_path: Path, monkeypatch) -> None:
+    fake = tmp_path / "my tools" / "atm"
+    fake.parent.mkdir(parents=True)
+    fake.write_text("#!/bin/sh\n", encoding="utf-8")
+    monkeypatch.setattr(install_mod.shutil, "which", lambda _: str(fake))
+
+    assert install_mod.resolve_atm_command() == shlex.quote(str(fake))
+
+
+def test_bindings_contain_no_bare_atm_command(tmp_path: Path, monkeypatch) -> None:
+    """四条绑定里出现的 atm 一律是绝对路径。"""
+    fake = tmp_path / ".local" / "bin" / "atm"
+    fake.parent.mkdir(parents=True)
+    fake.write_text("#!/bin/sh\n", encoding="utf-8")
+    monkeypatch.setattr(install_mod.shutil, "which", lambda _: str(fake))
+
+    conf = tmp_path / ".tmux.conf"
+    install_mod.apply(_plan(conf), live=False)
+
+    for line in conf.read_text(encoding="utf-8").splitlines():
+        if not line.startswith("bind-key"):
+            continue
+        assert str(fake) in line
+        assert "'atm " not in line and '"atm ' not in line


### PR DESCRIPTION
## 动机

装完 `atm install` 后按 `prefix + b`，tmux 只回一行：

```
'atm sidebar --toggle --pane %1' returned 127
```

127 = command not found。根因是 `resolve_atm_command()` 用 `shutil.which("atm")` 命中后返回**裸名** `"atm"` —— 那是安装时那个 shell 的 PATH，而 tmux server 用的是它**启动那一刻**的环境快照。`atm` 一般装在 `~/.local/bin`（uv tool / pipx），只要 server 比这条 PATH 更早起来就必踩。

本机实测 tmux server 的 PATH：

```
/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin
```

报错信息里没有任何线索指向 PATH，排查成本很高。

## 改动

- `resolve_atm_command()` 返回 `shlex.quote(shutil.which("atm"))`，即写进 `~/.tmux.conf` 的是完整绝对路径
- fallback 分支的 `sys.executable` 也一并 quote
- 模块 docstring 里「只要 `atm` 在 PATH 上就一直有效」那句删掉 —— 它正是这次出错的假设

零新依赖（`shlex` 本来就 import 了）。

## 影响面

`cli.py:380` 侧栏起 pane 时也调这个函数，但它在 `run-shell` 里执行，`which` 会落空、退回 `{sys.executable} -m atm`（本来就是绝对路径），所以**只有写进配置文件这条路径会踩**。

已经装过的用户重跑 `atm install` 即可，marker 块是幂等替换的。

## 验证

新增 3 条测试，先 RED 后 GREEN：

- `test_resolve_atm_command_returns_absolute_path`
- `test_resolve_atm_command_quotes_paths_with_spaces`
- `test_bindings_contain_no_bare_atm_command` —— 扫 conf 里每条 `bind-key`，断言不含裸 `'atm `

```
uv run --frozen pytest -q     → 213 passed
uv run ruff check src tests   → All checks passed!
uv run ruff format --check    → 30 files already formatted
```

真机复现与确认：改前 `prefix + b` 报 127；把绑定换成绝对路径后，用 tmux server 那份裸 PATH 跑 `env -i PATH=… /home/sean/.local/bin/atm sidebar --help` 退出码 0，键位恢复正常。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013sEf7UsypE7S8snoyjgyer
