### PR TITLE
fix: parse_panes 兼容 tmux 3.4 转义过的字段分隔符

### DIFF
--- a/app/src/atm/tmux.py
+++ b/app/src/atm/tmux.py
@@ -25,6 +25,8 @@ SIDEBAR_OPTION = "@atm_sidebar"
 
 # 用 \x1f (unit separator) 当分隔符：pane 标题和路径里可能有 | 或 tab，但不会有控制字符。
 _SEP = "\x1f"
+# tmux 3.4 把 _SEP 转义成这 4 个字面字符打出来；3.6 输出原字节。见 `_split_fields`。
+_SEP_ESCAPED = "\\037"
 _PANE_FORMAT = _SEP.join(
     [
         "#{pane_id}",
@@ -201,13 +203,30 @@ def list_panes() -> tuple[Pane, ...]:
     return parse_panes(run(["list-panes", "-a", "-F", _PANE_FORMAT]))
 
 
+def _split_fields(line: str) -> list[str]:
+    """按分隔符拆一行 —— 原始 \x1f 和 tmux 3.4 的字面量 `\\037` 都认。
+
+    tmux 3.4 会把格式串里的控制字符按八进制转义打出来（实测
+    `tmux display-message -p "A<0x1f>B"` → `A\\037B`），3.6 则输出原字节。
+    CONTRIBUTING 声明支持 3.0+，两种都得吃下去，否则 3.4 上每一行都因为
+    「只有 1 个字段」被跳过，`list_panes()` 返回空元组，
+    `atm sidebar --toggle` 报「找不到当前 pane %1」退出码 1。
+
+    只认死 `\\037` 这一个序列，不做通用的八进制反转义 —— pane 标题里真出现
+    反斜杠数字（`C:\\123`）不能被误伤。
+    """
+    if _SEP in line:
+        return line.split(_SEP)
+    return line.split(_SEP_ESCAPED)
+
+
 def parse_panes(stdout: str) -> tuple[Pane, ...]:
     """纯函数，方便测 —— tmux 的输出格式变了这里能第一时间测出来。"""
     panes: list[Pane] = []
     for line in stdout.splitlines():
         if not line.strip():
             continue
-        fields = line.split(_SEP)
+        fields = _split_fields(line)
         if len(fields) < 13:
             continue  # 格式对不上就跳过这一行，别让整个列表挂掉
         # 后加的字段允许缺席（老格式的输出照样能解析），缺了就取默认值。

--- a/app/tests/test_tmux_and_text.py
+++ b/app/tests/test_tmux_and_text.py
@@ -357,3 +357,29 @@ def test_plain_heading_is_not_stripped() -> None:
 
     assert strip_wrapper_blocks("# 我的笔记\n\n这段要保留").startswith("# 我的笔记")
     assert strip_wrapper_blocks("# 标题\n\n普通正文") == "# 标题\n\n普通正文"
+
+
+def test_parse_panes_accepts_tmux34_escaped_separator() -> None:
+    """tmux 3.4 把格式串里的 \\x1f 按八进制转义打成字面量 `\\037`（4 个字符）。
+
+    实测 tmux 3.4：
+        $ tmux display-message -p "A$(printf '\\037')B" | cat -A
+        A\\037B$
+    而开发基准 tmux 3.6 直接输出原始字节。CONTRIBUTING 声明支持 3.0+，
+    所以两种都得能解析 —— 否则 3.4 上 list_panes() 返回空元组，
+    `atm sidebar --toggle` 报「找不到当前 pane %1」退出码 1。
+    """
+    escaped = _pane_line().replace(SEP, "\\037")
+    assert SEP not in escaped
+
+    panes = tmux.parse_panes(escaped)
+
+    assert len(panes) == 1
+    assert panes[0].id == "%1"
+    assert panes[0].current_path == "/home/sean"
+    assert panes[0].title == "sean@host"
+
+
+def test_parse_panes_escaped_and_raw_mixed() -> None:
+    panes = tmux.parse_panes(_pane_line() + "\n" + _pane_line(id="%2").replace(SEP, "\\037"))
+    assert [p.id for p in panes] == ["%1", "%2"]


### PR DESCRIPTION
## 动机

`prefix + b` 报：

```
'/home/sean/.local/bin/atm sidebar --toggle --pane '%1'' returned 1
atm: 找不到当前 pane %1
```

但 `tmux list-panes -a` 明明列得出 `%1`。

根因：tmux 3.4 把格式串里的控制字符按**八进制转义成字面量**打出来，而开发基准 3.6 输出原字节。实测 3.4：

```
$ tmux -V
tmux 3.4
$ tmux display-message -p "A$(printf '\037')B" | cat -A
A\037B$
```

所以 `list-panes -F` 每一行里的分隔符是 `\037` 这 **4 个字符**，不是 `0x1F`。`parse_panes` 按 `_SEP` 拆只得到 1 个字段，被「格式对不上就跳过这一行」那条防御逐行吃掉，`list_panes()` 返回空元组。

讽刺的是这条防御本来是为了「别让一条脏行弄挂整个索引」，结果在 3.4 上把**所有**行都吞了，还一声不吭。

改前实测：

```
>>> tmux.list_panes()
()
>>> tmux.run(['list-panes','-a','-F',tmux._PANE_FORMAT])
'%1\\037main\\0370\\037claude\\0371\\037claude\\037/home/sean\\...'
```

## 改动

新增 `_split_fields()`：行里有原始 `0x1F` 就按它拆，否则按 `\037` 拆。

刻意**只认死 `\037` 这一个序列**，不做通用八进制反解 —— pane 标题里真出现反斜杠加数字（`C:\123`）不能被误伤。

零新依赖。

## 验证

新增 2 条测试，先 RED 后 GREEN：

- `test_parse_panes_accepts_tmux34_escaped_separator`
- `test_parse_panes_escaped_and_raw_mixed`（转义行与原字节行混排）

```
uv run --frozen pytest -q            → 215 passed
uv run --frozen ruff check src tests → All checks passed!
uv run --frozen ruff format --check  → 30 files already formatted
```

真机（tmux 3.4）：

| | 改前 | 改后 |
|---|---|---|
| `list_panes()` | 0 个 pane | 2 个 |
| `sidebar --toggle` 开 | exit 1 | exit 0，新 pane `%3`（32 列） |
| 再 toggle | — | 「切到侧栏 %3」exit 0 |
| 三次 toggle | — | 「收起侧栏 %3」exit 0，布局复原 |

## 备注

`CONTRIBUTING.md` 声明支持 tmux 3.0+，但 CI/开发只在 3.6 上跑过。这类版本差异建议后续在 `experiments/` 下补一个多版本隔离 socket 的冒烟脚本 —— 本 PR 不含。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013sEf7UsypE7S8snoyjgyer
