### PR TITLE
feat: 加入 Pi CLI 的会话源支持

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ai-terminal-manager
 
-**一句话**：一个面向 AI CLI（Claude Code / Codex）的终端管理器 —— 把两边的历史会话合成一份列表，
+**一句话**：一个面向 AI CLI（Claude Code / Codex / Pi）的终端管理器 —— 把各边的历史会话合成一份列表，
 选一条投进你指定的 tmux 格子；再加一个常驻左侧栏，用 `swap-pane` 在正在跑的会话之间换位。
 
 不做 GUI、不做布局同步 —— 那些 tmux 生态和官方 Desktop 已经吃掉了。atm 只做「AI 会话当一等公民」这一条。
@@ -12,7 +12,7 @@
 
 - Linux 或 WSL2 + **tmux ≥ 3.0**（开发基准 3.6）
 - **Python ≥ 3.11**，零运行时依赖
-- 装了 Claude Code 或 Codex 至少一个（atm 只读它们写在 `~/.claude/projects/`、`~/.codex/sessions/` 的会话文件）
+- 装了 Claude Code / Codex / Pi 至少一个（atm 只读它们写在 `~/.claude/projects/`、`~/.codex/sessions/`、`~/.pi/agent/sessions/` 的会话文件）
 
 ## 装
 
@@ -52,7 +52,7 @@ atm install     # 往 ~/.tmux.conf 写键位。会先把要写的内容打出来
 | `prefix + b` | **侧栏**：没开就在最左边开一条通高的；开了就切过去；已经在里面就收起 |
 | `prefix + B` | 把当前格子收进后台窗口 `bg` —— 进程继续跑，之后从侧栏里还能选回来 |
 
-浮层里：打字模糊搜索，`↑↓` / `^N` `^P` 移动，`Tab` 在 全部 / Claude / Codex 之间切，`⏎` 选中，`Esc` 取消。
+浮层里：打字模糊搜索，`↑↓` / `^N` `^P` 移动，`Tab` 在 全部 / Claude / Codex / Pi 之间循环，`⏎` 选中，`Esc` 取消。
 
 侧栏里：上半段是**正在跑的格子**（选中 → `swap-pane` 换进主格，进程不断），下半段是**历史**
 （选中 → 后台新窗口里 resume 再换进来）。`⏎` 换进主格，`^T` 挑具体换进哪格，`^X` 把选中的收进 `bg`，
@@ -61,7 +61,7 @@ atm install     # 往 ~/.tmux.conf 写键位。会先把要写的内容打出来
 命令行同样能用（不在 tmux 里时 `pick` 自动退化成打印命令，`eval "$(atm pick --print)"`）：
 
 ```bash
-atm list -n 20            # 列最近 20 条；--source codex 只看 Codex；--json 喂给别的脚本
+atm list -n 20            # 列最近 20 条；--source codex|claude|pi 只看一家；--json 喂给别的脚本
 atm pick                  # 交互选会话 → 选目标 pane → 投递
 atm resume <id前缀>       # 不进 TUI，按 id 直接投
 atm panes                 # 列出所有 tmux pane 及忙闲状态

--- a/app/README.md
+++ b/app/README.md
@@ -1,6 +1,6 @@
 # atm — AI Terminal Manager
 
-把 **Claude Code 和 Codex 的历史会话**合成一份统一列表，选一条，**投递到你指定的 tmux pane**。
+把 **Claude Code、Codex 和 Pi 的历史会话**合成一份统一列表，选一条，**投递到你指定的 tmux pane**。
 
 ```
 prefix + a  →  浮层里搜  →  Enter  →  选目标格子  →  会话在那个格子里恢复
@@ -12,7 +12,7 @@ prefix + a  →  浮层里搜  →  Enter  →  选目标格子  →  会话在�
 和 tmux 生态已经吃掉了**，历史浏览也有 clauhist / claude-sessions 在做。
 只剩一条没人做全：
 
-> **跨 agent（Claude + Codex）的统一历史 → 投到我指定的那个 pane。**
+> **跨 agent（Claude + Codex + Pi）的统一历史 → 投到我指定的那个 pane。**
 
 atm 就只做这一条。没有 GUI，没有控制模式解析器，没有布局同步 —— 那些都被砍掉了。
 
@@ -162,7 +162,7 @@ atm park                     # 把当前格子收进后台窗口 bg
 atm uninstall                # 干净移除
 
 atm list -n 20               # 列最近 20 条
-atm list --source codex      # 只看 Codex
+atm list --source codex      # 只看 Codex（还有 claude / pi）
 atm list --json              # 结构化输出，喂给别的脚本
 
 atm resume <id前缀>          # 不进 TUI，按 id 直接投
@@ -172,7 +172,7 @@ atm doctor                   # 体检
 ```
 
 选择器里：`↑↓` / `Ctrl-N` `Ctrl-P` 移动，直接打字模糊搜索，
-`Tab` 在 全部 / Claude / Codex 之间切，`Enter` 选中，`Esc` 取消。
+`Tab` 在 全部 / Claude / Codex / Pi 之间循环，`Enter` 选中，`Esc` 取消。
 
 **不在 tmux 里也能用** —— 这时 `pick` 自动退化成打印命令：
 
@@ -262,6 +262,19 @@ atm pick --no-mem-limit               # 关掉
   但它那几条 `thread_name` 是人类可读标题，留作标题来源
 - `~/.codex/thread_history_1.sqlite` 是**单线程的投影缓存**，不是全局索引，没用它
 - 恢复：`codex resume <SESSION_ID>`
+
+**Pi** `~/.pi/agent/sessions/--<cwd 把 '/' 换成 '-'>--/<ts>_<uuid>.jsonl`
+
+> ⚠️ **这一个是按上游文档写的，不是实测**。本机没装 pi，依据是 earendil-works/pi 的
+> `packages/coding-agent/docs/session-format.md`（schema `version: 3`）。
+> 字段对不上的话 `tests/test_sources.py` 里的 pi 用例会第一个红。
+
+- 第 1 行 `type:"session"` 是 SessionHeader，**只有它带 `cwd`**
+- 显示名走独立记录 `type:"session_info"` 的 `name`（`/name` 或 `--name` 产生），可改多次，取最后一条
+- 标题取首条 `message` 且 `message.role == "user"` —— pi 的 role 枚举比另外两家宽
+  （还有 `toolResult` / `bashExecution` / `compactionSummary` / `branchSummary`），不过滤会让 bash 输出冒充标题
+- schema v3 里**没有 git 字段**，所以 pi 的条目不显示分支
+- 恢复：`pi --session <id>`
 
 **所有会话文件一律只读。** 不原地改、不整理、不删。
 

--- a/app/src/atm/cli.py
+++ b/app/src/atm/cli.py
@@ -19,7 +19,7 @@ from . import dispatch as dispatch_mod
 from . import index as index_mod
 from . import tmux
 from .dispatch import DispatchError, DispatchTarget, TargetKind
-from .model import SessionEntry, SessionIndex, Source
+from .model import SOURCE_TAG, SessionEntry, SessionIndex, Source
 from .text import humanize_age, pad_display, truncate_display
 from .tmux import Pane, SplitDirection
 
@@ -240,7 +240,7 @@ def _cmd_list(args: argparse.Namespace) -> int:
     now = datetime.now(tz=UTC)
     for entry in limited:
         age = humanize_age((now - entry.updated_at).total_seconds())
-        tag = "CC" if entry.source is Source.CLAUDE else "CX"
+        tag = SOURCE_TAG.get(entry.source, "??")
         branch = f" ({entry.git_branch})" if entry.git_branch else ""
         named = f"⟨{entry.name}⟩ " if entry.name else ""
         print(
@@ -471,19 +471,21 @@ def _cmd_prune(args: argparse.Namespace) -> int:
 def _cmd_doctor(args: argparse.Namespace) -> int:
     from .sources import claude as claude_src
     from .sources import codex as codex_src
+    from .sources import pi as pi_src
 
     print("== 数据源 ==")
     claude_root = claude_src.DEFAULT_ROOT
     codex_root = codex_src.DEFAULT_ROOT
     _report_root("Claude", claude_root, len(list(claude_src.discover())))
     _report_root("Codex", codex_root, len(list(codex_src.discover())))
+    _report_root("Pi", pi_src.DEFAULT_ROOT, len(list(pi_src.discover())))
 
     legacy = codex_src.LEGACY_INDEX
     titles = codex_src.load_legacy_titles()
     print(f"  Codex 老索引 {legacy}: {'有' if legacy.exists() else '无'}（{len(titles)} 条标题）")
 
     print("\n== CLI ==")
-    for program in ("claude", "codex"):
+    for program in ("claude", "codex", "pi"):
         import shutil
 
         found = shutil.which(program)

--- a/app/src/atm/dispatch.py
+++ b/app/src/atm/dispatch.py
@@ -160,6 +160,9 @@ RESUME_PROGRAMS: dict[Source, tuple[str, ...]] = {
     Source.CLAUDE: ("claude", "--resume"),
     # 实测 `codex resume --help`：`Usage: codex resume [OPTIONS] [SESSION_ID] [PROMPT]`
     Source.CODEX: ("codex", "resume"),
+    # 上游文档 sessions.md：`--session <path|id>  Use a specific session file or partial session ID`
+    # （未在真机验证过，本机没装 pi。）
+    Source.PI: ("pi", "--session"),
 }
 
 

--- a/app/src/atm/index.py
+++ b/app/src/atm/index.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from . import cache as cache_mod
 from .cache import CachedEntry, IndexCache
 from .model import FileRef, IndexStats, SessionEntry, SessionIndex, Source
-from .sources import claude, codex
+from .sources import claude, codex, pi
 
 # ---------------------------------------------------------------- 噪音会话
 #
@@ -57,6 +57,7 @@ class SourceRoots:
     claude_root: Path | None = None
     codex_root: Path | None = None
     codex_legacy_index: Path | None = None
+    pi_root: Path | None = None
 
 
 def build(
@@ -72,7 +73,7 @@ def build(
     """
     started = time.perf_counter()
     roots = roots or SourceRoots()
-    wanted = set(sources) if sources is not None else {Source.CLAUDE, Source.CODEX}
+    wanted = set(sources) if sources is not None else set(Source)
 
     # 无论用不用缓存都要读它：`use_cache=False` 只表示「本轮不吃命中」，
     # 不表示「可以把别的来源的缓存也扔掉」。
@@ -129,6 +130,8 @@ def build(
         ingest(claude.discover(roots.claude_root), claude.parse)
     if Source.CODEX in wanted:
         ingest(codex.discover(roots.codex_root), lambda ref: codex.parse(ref, legacy_titles))
+    if Source.PI in wanted:
+        ingest(pi.discover(roots.pi_root), pi.parse)
 
     # 内容没变就别写盘。热路径下 100% 命中是常态，无脑重写会白白产生
     # 140KB 写入 + 一次 fsync —— 在 WSL 上这些字节最终要落到宿主的虚拟磁盘。
@@ -161,6 +164,8 @@ def _cached_source(path: str, cached: CachedEntry) -> Source | None:
         return cached.entry.source
     if "/.codex/" in path:
         return Source.CODEX
+    if "/.pi/" in path:
+        return Source.PI
     if "/.claude/" in path:
         return Source.CLAUDE
     return None

--- a/app/src/atm/model.py
+++ b/app/src/atm/model.py
@@ -20,6 +20,16 @@ class Source(StrEnum):
 
     CLAUDE = "claude"
     CODEX = "codex"
+    PI = "pi"
+
+
+# 列表里那两个字符的来源标记。放在 model 里是因为 cli / tui / sidebar_tui 三处都要用，
+# 而 cli.py 刻意不 import tui（tui 会在 import 时拉 curses）。
+SOURCE_TAG: dict[Source, str] = {
+    Source.CLAUDE: "CC",
+    Source.CODEX: "CX",
+    Source.PI: "PI",
+}
 
 
 @dataclass(frozen=True, slots=True)

--- a/app/src/atm/sidebar.py
+++ b/app/src/atm/sidebar.py
@@ -25,7 +25,7 @@ PARK_WINDOW = "bg"
 SIDEBAR_TITLE = "atm"
 
 # 侧栏把这些命令的格子排在前面 —— 它们才是「后台 AI 进程」，其余 pane 只是顺带列出。
-AI_COMMANDS = frozenset({"claude", "codex"})
+AI_COMMANDS = frozenset({"claude", "codex", "pi"})
 
 
 class SidebarError(RuntimeError):

--- a/app/src/atm/sidebar_tui.py
+++ b/app/src/atm/sidebar_tui.py
@@ -22,7 +22,7 @@ from . import index as index_mod
 from . import sidebar, tmux
 from .dispatch import DispatchError, DispatchTarget, MemoryLimit
 from .fuzzy import ScoredEntry, rank, score
-from .model import SessionEntry, Source
+from .model import SOURCE_TAG, SessionEntry, Source
 from .sidebar import SidebarError
 from .text import display_width, humanize_age, pad_display, tail_display, truncate_display
 from .tmux import Pane
@@ -47,7 +47,6 @@ _KEY_CTRL_X = 24
 _PANE_REFRESH_SECONDS = 1.0
 _INDEX_REFRESH_SECONDS = 15.0
 _STATUS_SECONDS = 6.0
-_SOURCE_TAG = {Source.CLAUDE: "CC", Source.CODEX: "CX"}
 
 
 @dataclass(frozen=True, slots=True)
@@ -228,7 +227,7 @@ class _Sidebar(_Screen):
             pass  # 下一轮 _draw 会按新尺寸画
 
     def _cycle_source(self) -> None:
-        order: list[Source | None] = [None, Source.CLAUDE, Source.CODEX]
+        order: list[Source | None] = [None, *Source]
         self._source_filter = order[(order.index(self._source_filter) + 1) % len(order)]
         self._recompute()
 
@@ -455,7 +454,7 @@ class _Sidebar(_Screen):
         entry = row.entry
         age = humanize_age((now - entry.updated_at).total_seconds())
         x = self._put(stdscr, y, 0, pad_display(age, 3), base | _color(5))
-        x = self._put(stdscr, y, x + 1, _SOURCE_TAG.get(entry.source, "??"), base | _color(3))
+        x = self._put(stdscr, y, x + 1, SOURCE_TAG.get(entry.source, "??"), base | _color(3))
         label = f"⟨{entry.name}⟩ {entry.title}" if entry.name else entry.title
         self._put(stdscr, y, x + 1, truncate_display(label, max(0, width - x - 2)), base)
 

--- a/app/src/atm/sources/__init__.py
+++ b/app/src/atm/sources/__init__.py
@@ -4,6 +4,6 @@
 两者都必须能容忍格式变化 —— 这两个 jsonl 的字段是逆向观察出来的，不是公开契约。
 """
 
-from . import claude, codex
+from . import claude, codex, pi
 
-__all__ = ["claude", "codex"]
+__all__ = ["claude", "codex", "pi"]

--- a/app/src/atm/sources/pi.py
+++ b/app/src/atm/sources/pi.py
@@ -1,0 +1,187 @@
+"""Pi 会话源：`~/.pi/agent/sessions/--<cwd 把 '/' 换成 '-'>--/<ts>_<uuid>.jsonl`。
+
+⚠️ **这个适配器是按上游公开文档写的，不是像 claude.py / codex.py 那样逆向观察出来的**
+（本机没装 pi，无真实语料可测）。依据是 earendil-works/pi 的
+`packages/coding-agent/docs/session-format.md`（schema `version: 3`）：
+
+- 第 1 行是 SessionHeader：`{"type":"session","version":3,"id":…,"timestamp":…,"cwd":…}`
+  —— **只有它带 `cwd`**，后续记录都没有，所以 cwd 必须从头部拿，拿不到才退回目录名。
+- 会话显示名走独立记录：`{"type":"session_info","name":"Refactor auth module"}`，
+  由 `/name` 或 `--name` 产生。**会重复出现**（可以改名多次），取最后一条。
+- 消息记录是 `{"type":"message","message":{"role":…,"content":…}}`，
+  注意 role 不止 user/assistant，还有 `toolResult` / `bashExecution` /
+  `compactionSummary` / `branchSummary` —— 只认 `user` 那一类当标题来源。
+- `content` 可能是裸字符串（user）也可能是 block 数组（assistant），和另外两家一样。
+
+因为是文档推导，解析全程走「拿不到就降级」而不是抛错：
+字段缺失退回文件名 / 目录名，整个目录不存在就安静返回空。
+真机跑起来后如果字段对不上，第一时间红的应该是 tests/test_sources.py 里的 pi 用例。
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Iterator
+from pathlib import Path
+
+from ..jsonl import iter_head_records, iter_tail_records
+from ..model import UNTITLED, FileRef, SessionEntry, Source
+from ..text import clean_title, is_junk_prompt
+
+DEFAULT_ROOT = Path.home() / ".pi" / "agent" / "sessions"
+
+_MAX_RECORDS = 400
+
+# `--home-user-myapp--`：前后各两个连字符包住，中间把 '/' 换成 '-'。
+_PROJECT_DIR_RE = re.compile(r"^--(?P<body>.*)--$")
+# 文件名 `2024-12-03T14_00_00_abc123.jsonl` 的尾段就是 session id。
+_ID_RE = re.compile(r"^[0-9A-Za-z-]+$")
+
+
+def discover(root: Path | None = None) -> Iterator[FileRef]:
+    """列出所有会话文件。目录不存在就安静返回空。
+
+    只扫一层（`*/*.jsonl`），和 claude.py 同样的理由：会话文件直接躺在
+    per-cwd 目录下，再往深处递归只会捞进将来可能出现的衍生产物。
+    """
+    base = root or DEFAULT_ROOT
+    if not base.is_dir():
+        return
+    for path in base.glob("*/*.jsonl"):
+        ref = FileRef.from_path(path)
+        if ref is not None and ref.size_bytes > 0:
+            yield ref
+
+
+def decode_project_dir(name: str) -> str:
+    """`--home-user-myapp--` → `/home/user/myapp`。
+
+    和 claude 那边一样是**有损**的（目录名里本来就有的 '-' 分不出来），
+    所以只当 cwd 的兜底 —— SessionHeader 里读到真的 cwd 一律优先。
+    """
+    match = _PROJECT_DIR_RE.match(name)
+    if match is None:
+        return name
+    body = match.group("body")
+    return "/" + body.replace("-", "/") if body else "/"
+
+
+def parse(ref: FileRef) -> SessionEntry | None:
+    session_id = ""
+    cwd = ""
+    title = ""
+    name = ""
+    saw_any = False
+
+    for index, record in enumerate(iter_head_records(ref.path)):
+        if index >= _MAX_RECORDS:
+            break
+        saw_any = True
+        record_type = record.get("type")
+
+        if record_type == "session":
+            # 分叉出来的会话带 `parentSession`，但它**仍然可以独立 resume**
+            # （`--fork` 产生的是一个完整的新会话文件），所以不像 codex 的子 agent 那样排除。
+            session_id = _first_str(record.get("id")) or session_id
+            cwd = _first_str(record.get("cwd")) or cwd
+
+        elif record_type == "session_info":
+            candidate = record.get("name")
+            if isinstance(candidate, str) and candidate.strip():
+                name = clean_title(candidate, limit=40)  # 后写的覆盖先写的 = 最后一次改名
+
+        elif not title and record_type == "message":
+            text = _user_text(record)
+            if text and not is_junk_prompt(text):
+                title = clean_title(text)
+
+        if title and cwd and session_id:
+            break
+
+    if not saw_any:
+        return None
+
+    # 改名可以发生在会话任何时刻，头部窗口未必覆盖 —— 尾部再扫一遍取最后一个 name。
+    # （claude.py 踩过这个坑：14 个命名会话里 4 个的改名在头部窗口之外。）
+    tail_name = _scan_tail_name(ref.path)
+    name = tail_name or name
+
+    path = Path(ref.path)
+    if not session_id:
+        session_id = _id_from_filename(path.stem)
+    if not session_id:
+        return None
+    if not cwd:
+        cwd = decode_project_dir(path.parent.name)
+
+    return SessionEntry(
+        id=session_id,
+        title=title or UNTITLED,
+        source=Source.PI,
+        cwd=cwd or str(Path.home()),
+        git_branch=None,  # session-format.md 的 schema v3 里没有 git 字段
+        updated_at=ref.updated_at,
+        path=ref.path,
+        size_bytes=ref.size_bytes,
+        name=name or None,
+    )
+
+
+def _scan_tail_name(path: str) -> str:
+    name = ""
+    for record in iter_tail_records(path):
+        if record.get("type") != "session_info":
+            continue
+        candidate = record.get("name")
+        if isinstance(candidate, str) and candidate.strip():
+            name = clean_title(candidate, limit=40)
+    return name
+
+
+def _user_text(record: dict) -> str:
+    """只认 role == "user" 的消息。
+
+    ⚠️ pi 的 role 枚举比另外两家宽：`user` / `assistant` / `toolResult` /
+    `bashExecution` / `custom` / `branchSummary` / `compactionSummary`。
+    不做这层过滤的话，一条 compaction 摘要或者 bash 输出会冒充标题。
+    """
+    message = record.get("message")
+    if not isinstance(message, dict) or message.get("role") != "user":
+        return ""
+    return _blocks_to_text(message.get("content"))
+
+
+def _blocks_to_text(content: object) -> str:
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, Iterable) or isinstance(content, (bytes, dict)):
+        return ""
+
+    parts: list[str] = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") != "text":
+            continue
+        text = block.get("text")
+        if isinstance(text, str) and text.strip():
+            parts.append(text)
+    return "\n".join(parts)
+
+
+def _id_from_filename(stem: str) -> str:
+    """`2024-12-03T14_00_00_abc123` → `abc123`。
+
+    按 '_' 拆取最后一段。拆不出合法形状就返回空串让调用方丢弃 ——
+    codex.py 踩过这个坑：拼出假 id 喂给 CLI 只会报「找不到会话」，
+    比列表里少一条更难查。
+    """
+    candidate = stem.rsplit("_", 1)[-1]
+    return candidate if candidate and _ID_RE.match(candidate) else ""
+
+
+def _first_str(*candidates: object) -> str:
+    for candidate in candidates:
+        if isinstance(candidate, str) and candidate.strip():
+            return candidate
+    return ""

--- a/app/src/atm/tui.py
+++ b/app/src/atm/tui.py
@@ -19,10 +19,8 @@ from pathlib import Path
 
 from . import dispatch
 from .fuzzy import ScoredEntry, rank
-from .model import SessionEntry, Source
+from .model import SOURCE_TAG, SessionEntry, Source
 from .text import display_width, humanize_age_ago, pad_display, tail_display, truncate_display
-
-_SOURCE_TAG = {Source.CLAUDE: "CC", Source.CODEX: "CX"}
 
 # 各列的固定宽度（显示宽度，不是字符数）
 _AGE_WIDTH = 9
@@ -69,7 +67,7 @@ class GroupMode(StrEnum):
         return order[(order.index(self) + 1) % len(order)]
 
 
-_AGENT_NAME = {Source.CLAUDE: "Claude Code", Source.CODEX: "Codex"}
+_AGENT_NAME = {Source.CLAUDE: "Claude Code", Source.CODEX: "Codex", Source.PI: "Pi"}
 
 
 @dataclass(frozen=True, slots=True)
@@ -279,7 +277,7 @@ class _SessionPicker(_Screen):
         return None
 
     def _cycle_source(self) -> None:
-        order: list[Source | None] = [None, Source.CLAUDE, Source.CODEX]
+        order: list[Source | None] = [None, *Source]
         self._source_filter = order[(order.index(self._source_filter) + 1) % len(order)]
         self._recompute()
 
@@ -477,7 +475,7 @@ class _SessionPicker(_Screen):
         age = _age_label(entry, now)
         x = self._put(stdscr, y, 0, pad_display(age, _AGE_WIDTH), base | _color(5))
         x += _GUTTER
-        tag = _SOURCE_TAG.get(entry.source, "??")
+        tag = SOURCE_TAG.get(entry.source, "??")
         x = self._put(stdscr, y, x, pad_display(tag, _TAG_WIDTH), base | _color(3))
         x += _GUTTER
         project = pad_display(entry.project_name, _PROJECT_WIDTH)

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -61,3 +61,8 @@ def claude_session(claude_root: Path) -> Path:
             {"type": "assistant", "message": {"role": "assistant", "content": "好的"}},
         ],
     )
+
+
+@pytest.fixture
+def pi_root(tmp_path: Path) -> Path:
+    return tmp_path / "pi" / "agent" / "sessions"

--- a/app/tests/test_dispatch.py
+++ b/app/tests/test_dispatch.py
@@ -67,6 +67,24 @@ def test_resume_command_for_codex() -> None:
     assert command.shell_line() == "cd /tmp && codex resume aaaa-bbbb"
 
 
+def test_resume_command_for_pi() -> None:
+    """上游文档 sessions.md：`--session <path|id>` 接完整路径或**部分** session id。
+
+    传完整 id 而不是路径，和另外两家保持一致（路径里有空格照样能过 shlex，
+    但 id 更短、也是 pi 自己 `-r` 列表里显示的东西）。
+    """
+    command = resume_command(make_entry(Source.PI))
+    assert command.program == "pi"
+    assert command.argv == ("--session", "aaaa-bbbb")
+    assert command.shell_line() == "cd /tmp && pi --session aaaa-bbbb"
+
+
+def test_every_source_has_a_resume_command() -> None:
+    """加了新 Source 却忘了在 RESUME_PROGRAMS 里登记 —— 只会在用户点下去那一刻炸。"""
+    for source in Source:
+        assert resume_command(make_entry(source)).program
+
+
 def test_shell_line_quotes_dangerous_cwd() -> None:
     """cwd 里有空格/引号/分号时必须转义 —— 否则会执行到别的命令。"""
     entry = make_entry(cwd="/tmp")

--- a/app/tests/test_grouping.py
+++ b/app/tests/test_grouping.py
@@ -197,3 +197,12 @@ def test_control_chars_stripped_before_drawing() -> None:
     assert _Screen._sanitize("A\x1b[31mRED\x07B") == "A[31mREDB"
     assert _Screen._sanitize("正常标题") == "正常标题"
     assert _Screen._sanitize("tab\there") == "tab\there"
+
+
+def test_every_source_has_a_display_tag() -> None:
+    """新加 Source 忘了配标记的话，列表里会出现一列 `??`。"""
+    from atm.model import SOURCE_TAG, Source
+
+    for source in Source:
+        assert SOURCE_TAG.get(source), source
+        assert len(SOURCE_TAG[source]) == 2, source

--- a/app/tests/test_sources.py
+++ b/app/tests/test_sources.py
@@ -9,7 +9,7 @@ import json
 from pathlib import Path
 
 from atm.model import UNTITLED, FileRef, Source
-from atm.sources import claude, codex
+from atm.sources import claude, codex, pi
 
 from .conftest import write_jsonl
 
@@ -391,3 +391,153 @@ def test_claude_takes_latest_ai_title(claude_root: Path) -> None:
     entry = claude.parse(FileRef.from_path(path))
     assert entry is not None
     assert entry.title == "最终的标题"
+
+
+# ---------------------------------------------------------------- pi
+#
+# ⚠️ 和上面两组不同：pi 的记录形状**照上游文档写的，不是实测语料**
+# （见 sources/pi.py 的模块 docstring）。真机跑起来后如果字段对不上，
+# 这一组会第一个红 —— 那正是它存在的意义。
+
+
+def _pi_file(root: Path, session_id: str, *, extra: list[dict | str] | None = None) -> Path:
+    return write_jsonl(
+        root / "--home-sean-IdeaProjects-demo--" / f"2026-09-05T01_20_00_{session_id}.jsonl",
+        [
+            {
+                "type": "session",
+                "version": 3,
+                "id": session_id,
+                "timestamp": "2026-09-05T01:20:00.000Z",
+                "cwd": "/home/sean/IdeaProjects/demo",
+            },
+            *(extra or []),
+        ],
+    )
+
+
+def _pi_user(text: str, entry_id: str = "a1b2c3d4") -> dict:
+    return {
+        "type": "message",
+        "id": entry_id,
+        "parentId": None,
+        "timestamp": "2026-09-05T01:20:01.000Z",
+        "message": {"role": "user", "content": text},
+    }
+
+
+def test_pi_parse_reads_header_and_first_user_message(pi_root: Path) -> None:
+    path = _pi_file(pi_root, "abc12345", extra=[_pi_user("把索引层的缓存加上")])
+
+    entry = pi.parse(FileRef.from_path(path))
+
+    assert entry is not None
+    assert entry.source is Source.PI
+    assert entry.id == "abc12345"
+    assert entry.title == "把索引层的缓存加上"
+    assert entry.cwd == "/home/sean/IdeaProjects/demo"
+    assert entry.git_branch is None  # schema v3 没有 git 字段
+
+
+def test_pi_ignores_non_user_roles_as_title(pi_root: Path) -> None:
+    """role 枚举比另外两家宽 —— toolResult / bashExecution / compactionSummary
+    都不能冒充标题，否则列表里会出现一堆 bash 输出。"""
+    noise = [
+        {"type": "message", "message": {"role": "toolResult", "content": "exit 0"}},
+        {"type": "message", "message": {"role": "bashExecution", "content": "ls -la"}},
+        {"type": "message", "message": {"role": "compactionSummary", "content": "用户讨论了 X"}},
+        {
+            "type": "message",
+            "message": {"role": "assistant", "content": [{"type": "text", "text": "好的"}]},
+        },
+    ]
+    path = _pi_file(pi_root, "abc12345", extra=[*noise, _pi_user("真正的第一句")])
+
+    entry = pi.parse(FileRef.from_path(path))
+
+    assert entry is not None
+    assert entry.title == "真正的第一句"
+
+
+def test_pi_session_info_becomes_name(pi_root: Path) -> None:
+    path = _pi_file(
+        pi_root,
+        "abc12345",
+        extra=[
+            _pi_user("随便问点什么"),
+            {"type": "session_info", "id": "k1l2m3n4", "name": "Refactor auth module"},
+        ],
+    )
+
+    entry = pi.parse(FileRef.from_path(path))
+
+    assert entry is not None
+    assert entry.name == "Refactor auth module"
+
+
+def test_pi_takes_latest_rename(pi_root: Path) -> None:
+    path = _pi_file(
+        pi_root,
+        "abc12345",
+        extra=[
+            _pi_user("随便问点什么"),
+            {"type": "session_info", "name": "旧名字"},
+            {"type": "session_info", "name": "新名字"},
+        ],
+    )
+
+    entry = pi.parse(FileRef.from_path(path))
+
+    assert entry is not None
+    assert entry.name == "新名字"
+
+
+def test_pi_tolerates_corrupt_lines(pi_root: Path) -> None:
+    path = _pi_file(pi_root, "abc12345", extra=["{ 不是 json", _pi_user("脏行后面的正常消息")])
+
+    entry = pi.parse(FileRef.from_path(path))
+
+    assert entry is not None
+    assert entry.title == "脏行后面的正常消息"
+
+
+def test_pi_falls_back_to_filename_id_and_decoded_dir(pi_root: Path) -> None:
+    """header 整行坏掉时也不能让这条会话从列表里消失。"""
+    path = write_jsonl(
+        pi_root / "--home-sean-IdeaProjects-demo--" / "2026-09-05T01_20_00_deadbeef.jsonl",
+        [_pi_user("没有 header 的会话")],
+    )
+
+    entry = pi.parse(FileRef.from_path(path))
+
+    assert entry is not None
+    assert entry.id == "deadbeef"
+    assert entry.cwd == "/home/sean/IdeaProjects/demo"
+    assert entry.title == "没有 header 的会话"
+
+
+def test_pi_untitled_when_no_user_message(pi_root: Path) -> None:
+    entry = pi.parse(FileRef.from_path(_pi_file(pi_root, "abc12345")))
+    assert entry is not None
+    assert entry.title == UNTITLED
+
+
+def test_pi_discover_finds_sessions(pi_root: Path) -> None:
+    _pi_file(pi_root, "abc12345")
+    assert len(list(pi.discover(pi_root))) == 1
+
+
+def test_pi_discover_on_missing_root(tmp_path: Path) -> None:
+    assert list(pi.discover(tmp_path / "nope")) == []
+
+
+def test_pi_decode_project_dir_strips_the_double_dashes() -> None:
+    assert pi.decode_project_dir("--home-user-myapp--") == "/home/user/myapp"
+    # 形状对不上就原样返回，别拼出一个假路径
+    assert pi.decode_project_dir("weird") == "weird"
+
+
+def test_pi_id_from_filename_rejects_garbage() -> None:
+    assert pi.parse.__module__.endswith("pi")  # 防止 import 写错指到别的模块
+    assert pi._id_from_filename("2026-09-05T01_20_00_abc123") == "abc123"
+    assert pi._id_from_filename("") == ""


### PR DESCRIPTION
## 动机

CONTRIBUTING 里「永远欢迎」的第一条就是新 CLI 的会话数据源适配。这个 PR 加 [Pi](https://github.com/earendil-works/pi)。

## ⚠️ 先说清楚：这个适配器是按文档写的，不是实测

另外两个源（`claude.py` / `codex.py`）的字段是在本机真实语料上逆向观察出来的，`conftest.py` 的开头也专门写了「不是照文档猜的」。**这一个做不到** —— 本机没装 pi，没有语料。

依据是上游 `packages/coding-agent/docs/session-format.md`，schema `version: 3`。

这一点在三处显式标注了，不藏着：模块 docstring、`app/README.md` 的数据源一节、`tests/test_sources.py` 的 pi 分节注释。解析全程「拿不到就降级」而不是抛错 —— 字段缺失退回文件名/目录名，目录不存在安静返回空。字段真对不上时，`tests/test_sources.py` 的 pi 用例会第一个红，那正是它存在的意义。

**合并前建议在装了 pi 的机器上跑一次 `atm doctor` + `atm list --source pi` 核对。**

## 格式要点

`~/.pi/agent/sessions/--<cwd 把 '/' 换成 '-'>--/<ts>_<uuid>.jsonl`

| | 结论 | 为什么要特别处理 |
|---|---|---|
| cwd | 只在第 1 行 `type:"session"` 的 SessionHeader 里 | 后续记录都没有 cwd，头部拿不到就只能退回有损的目录名 |
| 显示名 | 独立记录 `type:"session_info"` 的 `name` | 可以改多次 —— 照 `claude.py` 踩过的坑（14 个命名会话里 4 个的改名在头部窗口之外），头部扫完再扫尾部取最后一个 |
| 标题 | 首条 `message` 且 `message.role == "user"` | pi 的 role 枚举比另外两家宽：还有 `toolResult` / `bashExecution` / `compactionSummary` / `branchSummary`。不过滤会让一段 bash 输出或压缩摘要冒充标题 |
| 分支 | 恒为 `None` | schema v3 里根本没有 git 字段 |
| fork | **不排除** | `--fork` 产生的是完整可 resume 的会话文件，和 codex 的子 agent（id 指向父线程、resume 不了）不是一回事 |

恢复命令：`pi --session <id>`（上游 `sessions.md`：`--session <path|id>`）。传 id 而不是路径，和另外两家保持一致。

## 顺带清理

来源标记原本在 `tui.py` 和 `sidebar_tui.py` 各定义了一份，而 `cli.py:243` 是写死的三元表达式：

```python
tag = "CC" if entry.source is Source.CLAUDE else "CX"
```

对任何新来源都会返回 `"CX"`。收进 `model.SOURCE_TAG` 单一来源（放 model 而不是 tui，是因为 `cli.py` 刻意不 import `tui` —— 那会在 import 时拉 curses）。

TUI 的 Tab 过滤顺序从写死的 `[None, Source.CLAUDE, Source.CODEX]` 改成 `[None, *Source]`，`index.py` 的默认 `wanted` 同理改成 `set(Source)` —— 以后加一家不用再改这几处。

零新依赖。

## 验证

新增 15 条测试：

- pi 解析 11 条：header+首条 user、非 user role 不冒充标题、`session_info` 变 name、取最后一次改名、脏行容忍、header 坏掉时退回文件名 id + 目录名 cwd、无 user 消息给 UNTITLED、discover、目录不存在、目录名解码有损性、假 id 拒绝
- 两条守卫，防止以后加 Source 忘了配套：`test_every_source_has_a_resume_command`、`test_every_source_has_a_display_tag`
- `test_resume_command_for_pi`

```
uv run --frozen pytest -q            → 229 passed
uv run --frozen ruff check src tests → All checks passed!
uv run --frozen ruff format src tests → 31 files left unchanged
```

端到端（合成语料，理由同上）：

```
pi abc12345 'pi source adapter' '给 atm 加上 pi 的会话源支持' /home/sean/projects/ai-terminal-manager
  -> pi --session abc12345
```

`atm doctor` 在没装 pi 的机器上：

```
  Pi /home/sean/.pi/agent/sessions: 不存在，0 个会话文件
  pi: 不在 PATH 里 —— 投递出去会失败
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013sEf7UsypE7S8snoyjgyer
