### PR TITLE
feat: atm config + atm claude/codex/pi 按配置的内存闸门启动

### DIFF
--- a/README-cn.md
+++ b/README-cn.md
@@ -84,6 +84,9 @@ atm install     # 往 ~/.tmux.conf 写键位 + 装 resurrect/continuum。先把�
   刻意**不**让它重新拉起 claude / codex ——开机批量拉起会瞬间吃光内存（`research/notes/2026-08-12-incident.md` 附三）；
   会话由你在对应格子里按需 resume。不想要：`--no-persist`。你自己已经在用 tpm 会自动跳过，不重复写。
 
+可选：`atm config memory.high 4G` 设一次，之后 `atm claude` / `atm codex` / `atm pi` 就在 cgroup 内存闸门里启动；
+直接敲 `claude` 仍然不受限——前缀即选择。见 [docs/usage-cn.md](docs/usage-cn.md)。
+
 tmux 没装的话 `atm install` 给出对应包管理器的安装命令，不替你跑 sudo。
 卸载：`atm uninstall && uv tool uninstall ai-terminal-manager`——只删这两个块，你自己的配置一个字不动，克隆下来的插件也不动。
 

--- a/README-ja.md
+++ b/README-ja.md
@@ -85,6 +85,9 @@ atm install     # ~/.tmux.conf にキーバインドを書き + resurrect/contin
   （`research/notes/2026-08-12-incident.md` 付録三）。セッションは対応する pane で必要なときに resume する。不要なら `--no-persist`。
   自分で tpm を管理している場合は自動でスキップし、二重に書かない。
 
+任意：`atm config memory.high 4G` を一度設定すれば、以後 `atm claude` / `atm codex` / `atm pi` は cgroup のメモリゲート内で起動する；
+素の `claude` は制限なしのまま——プレフィックスが選択。詳細は [docs/usage-ja.md](docs/usage-ja.md)。
+
 tmux が入っていなければ `atm install` がパッケージマネージャに応じたインストールコマンドを表示する。sudo は代わりに実行しない。
 アンインストール：`atm uninstall && uv tool uninstall ai-terminal-manager`——この二つのブロックだけを消し、あなた自身の設定は一文字も触らず、clone したプラグインも残す。
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ atm install     # write key bindings to ~/.tmux.conf + install resurrect/continu
   right pane. Don't want it: `--no-persist`. If you already manage tpm yourself it is skipped, nothing is written
   twice.
 
+Optional but recommended on a shared or memory-tight box: `atm config memory.high 4G` then launch with
+`atm claude` / `atm codex` / `atm pi` to run inside a cgroup memory gate. Plain `claude` stays unlimited —
+the prefix is the choice. See [docs/usage.md](https://github.com/lyfuci/ai-terminal-manager/blob/main/docs/usage.md).
+
 If tmux isn't installed, `atm install` prints the install command for your package manager; it never runs sudo for
 you. Uninstall: `atm uninstall && uv tool uninstall ai-terminal-manager` — removes only those two blocks, not a character of your
 own config, and leaves the cloned plugins alone.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -184,20 +184,45 @@ eval "$(atm pick --print)"
 
 ## 内存闸门（默认开）
 
-每次投递会把会话裹进一个带 cgroup 限制的 systemd scope：
+两层，都是 cgroup：
 
+| 层 | 管什么 | 谁设 |
+|---|---|---|
+| **单会话** scope | 一个会话（含它拉起的 MCP server / bash 工具等子进程）最多用多少 | `atm config memory.high / memory.max` |
+| **总量** slice | 所有 atm 启动或投递的会话合计最多用多少 | `atm install` 写 `~/.config/systemd/user/atm-ai.slice`，按物理内存 50% / 65% |
+
+### 三条进闸门的路，一条不进
+
+```bash
+atm claude --resume <id>     # 带闸门启动 claude；参数原样透传，包括 --help
+atm codex resume <id>        # 同理
+atm pi --session <id>
+claude                       # 不带 atm 前缀 = 原生，不套任何限制
 ```
-cd <cwd> && systemd-run --user --scope -q --description 'atm: <名字>' \
-    -p MemoryHigh=2G -p MemoryMax=4G -p MemorySwapMax=512M \
-    claude --resume <id>
+
+`prefix + a` 投递和侧栏恢复历史走的是同一套参数。**前缀即选择**：atm 不劫持 `claude` 命令本身，
+你随时可以裸跑。
+
+### 配置
+
+```bash
+atm config                        # 看当前值（哪些是默认、哪些设过）
+atm config memory.high 4G         # 软上限：超了节流 + 回收，不杀
+atm config memory.max 8G          # 硬上限：回收压不住才杀 —— 杀的是整个 scope，会话和它的子命令一起没
+atm config memory.enabled false   # 全关（atm claude 就等于 claude）
+atm config --unset memory.high    # 恢复单项默认
+atm config --reset                # 全部默认
 ```
 
-**为什么需要**：实测一个持续干活 1h40m 的 claude 会话内存峰值到过 **4.7GB**，
-四个长会话合计约 8GB —— 正好是本机 WSL 的上限。撞上限的后果不是「那个会话变慢」，
-而是**整个 tmux server 连同所有会话一起死掉**（2026-08-12 11:59 实际发生过一次）。
-套上 cgroup 后，最坏情况从「全丢」变成「丢一个」。
+配置文件 `~/.config/atm/config.toml`（尊重 `$XDG_CONFIG_HOME`），改完立即生效。
+其它可设项：`memory.swap-max`（默认 512M，WSL 的 swap 在宿主 SSD 上，别放大）、
+`memory.slice`（默认 `atm-ai.slice`）、`memory.user`（systemd-run 是否走 `--user`，一般 true）。
 
-**阈值怎么来的**（journal 里 25 个真实会话的 `memory.peak` 分布）：
+单次覆盖：`atm pick --mem-high 3G --mem-max 6G`、`atm pick --no-mem-limit`。
+
+### 默认值怎么来的
+
+单会话默认 **2G / 4G**，来自 8G 机器上 25 个真实会话的 `memory.peak` 分布：
 
 | 上限 | 会杀掉 |
 |---|---|
@@ -205,24 +230,23 @@ cd <cwd> && systemd-run --user --scope -q --description 'atm: <名字>' \
 | **2G** | **1/25（4%）** |
 | 4G | 1/25（4%）|
 
-2G 是拐点 —— 再往上加没有任何改善，只有那个 4813MB 的失控户超标。
+2G 是拐点——再往上加没有改善，只有那个 4813MB 的失控户超标。**大内存机器请自己往上调**
+（48G 的机器 4G / 8G 比较合理）：默认值偏保守是因为它是为 8G 的 WSL 定的，不是为你的机器定的。
 
-**为什么 High/Max 分开**：实测峰值大多是**瞬时尖峰**，同一批会话 peak→current 回落达 60~75%。
-所以 `MemoryHigh` 只节流 + 强制回收（**不杀**），让尖峰自然被压回去；
-`MemoryMax` 是硬底线，只在回收也压不住时才动手。只设 Max 会误杀正常尖峰。
+**为什么 High / Max 分开**：实测峰值大多是瞬时尖峰，同一批会话 peak→current 回落 60~75%。
+`MemoryHigh` 只节流 + 强制回收（**不杀**），让尖峰自然压回去；`MemoryMax` 是硬底线。只设 Max 会误杀正常尖峰。
 
-**内存增长跟「开多久」无关，跟「干多少活」有关** —— 实测一个挂了 22h35m 的会话只用 346MB，
-而一个 CPU 时间 49 分钟的会话到了 4.7GB。tmux 不参与任何内存管理；claude 也确实会回收
-（那 60~75% 的回落就是证据）。
+**内存增长跟「开多久」无关，跟「干多少活」有关**——一个挂了 22h35m 的会话只用 346MB，
+一个 CPU 时间 49 分钟的会话到了 4.7GB。
 
-调整：
+### 为什么需要
 
-```bash
-atm pick --mem-high 3G --mem-max 6G   # 放宽
-atm pick --no-mem-limit               # 关掉
-```
+一个持续干活的 claude 会话内存峰值到过 **4.7GB**，四个长会话合计约 8GB——正好是当时 WSL 的上限。
+撞上限的后果不是「那个会话变慢」，而是**整个 tmux server 连同所有会话一起死掉**（2026-08-12 11:59 实际发生过）。
+套上 cgroup 后，最坏情况从「全丢」变成「丢一个」。
 
-拿不到 cgroup 支持（无 systemd user manager / memory 控制器未 delegate）时**静默降级为不限**。
+拿不到 cgroup 支持（无 systemd user manager / memory 控制器未 delegate）时**静默降级为不限**，
+`atm config` 和 `atm doctor` 会把这件事说出来。
 
 ## 实测数字（不是估的）
 

--- a/docs/usage-cn.md
+++ b/docs/usage-cn.md
@@ -46,6 +46,19 @@ atm index --rebuild       # 清缓存全量重建
 
 ---
 
+## 内存闸门：`atm claude` 和 `claude` 的区别
+
+```bash
+atm config memory.high 4G      # 软上限：节流 + 回收，不杀
+atm config memory.max 8G       # 硬上限：杀整个会话 scope（含子进程）
+atm claude --resume <id>       # 在这个 cgroup 里启动 claude；参数原样透传
+claude                         # 不带前缀 = 原生，不套任何限制
+```
+
+`atm codex …` / `atm pi …` 同理。`prefix + a` 投递和侧栏恢复用的是同一套设置。
+`atm install` 还会写一个总量 `atm-ai.slice`（物理内存的 50% / 65%），N 个会话加起来也压不垮机器；
+`atm doctor` 两层都报。默认值怎么来的见 [reference.md](reference.md#内存闸门默认开)。
+
 ## 它怎么工作（三分钟版）
 
 **「记住状态」其实是三层**，atm 只碰其中两层，第三层交给 tmux：

--- a/docs/usage-ja.md
+++ b/docs/usage-ja.md
@@ -46,6 +46,19 @@ atm index --rebuild       # キャッシュを消して全再構築
 
 ---
 
+## メモリゲート：`atm claude` と `claude` の違い
+
+```bash
+atm config memory.high 4G      # ソフト上限：スロットリング + 回収、殺さない
+atm config memory.max 8G       # ハード上限：セッションの scope 全体（子プロセス含む）を kill
+atm claude --resume <id>       # その cgroup 内で claude を起動；引数はそのまま透過
+claude                         # プレフィックスなし = ネイティブ、制限なし
+```
+
+`atm codex …` / `atm pi …` も同じ。`prefix + a` の投入とサイドバーの resume も同じ設定を使う。
+`atm install` は合計用の `atm-ai.slice`（物理メモリの 50% / 65%）も書き、N 本合計でもマシンを落とさない；
+`atm doctor` は両層を報告する。デフォルト値の根拠は [reference.md](reference.md#内存闸门默认开)。
+
 ## 仕組み（三分版）
 
 **「状態を覚える」は実は三層**。atm はそのうち二層に触れ、残りは tmux に任せる：

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -49,6 +49,20 @@ Development and contributing: [CONTRIBUTING.md](../CONTRIBUTING.md).
 
 ---
 
+## Memory gate: `atm claude` vs `claude`
+
+```bash
+atm config memory.high 4G      # soft cap: throttle + reclaim, never kills
+atm config memory.max 8G       # hard cap: kills the whole session scope (children included)
+atm claude --resume <id>       # launches claude inside that cgroup; args pass through untouched
+claude                         # no prefix = native, no limits at all
+```
+
+`atm codex …` and `atm pi …` work the same. `prefix + a` dispatch and sidebar resume use the same settings.
+`atm install` also writes an aggregate `atm-ai.slice` (50% / 65% of RAM) so N sessions together can't
+take the machine down; `atm doctor` reports both layers. Details and the numbers behind the defaults:
+[reference.md](reference.md#内存闸门默认开).
+
 ## How it works (three-minute version)
 
 **"Remembering state" is really three layers.** atm touches two of them and leaves the third to tmux:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 # PyPI 上 `atm` 已被占用；发行名用全名，命令名仍是 `atm`。
 name = "ai-terminal-manager"
-version = "0.1.1"
+version = "0.2.0"
 description = "Multi-session manager for AI CLIs (Claude Code / Codex / Pi) inside tmux: unified history, resume into any pane, persistent sidebar"
 readme = "README.md"
 license = "MIT"

--- a/src/atm/__init__.py
+++ b/src/atm/__init__.py
@@ -9,6 +9,6 @@
 
 from .model import IndexStats, SessionEntry, SessionIndex, Source
 
-__version__ = "0.1.1"
+__version__ = "0.2.0"
 
 __all__ = ["IndexStats", "SessionEntry", "SessionIndex", "Source", "__version__"]

--- a/src/atm/cli.py
+++ b/src/atm/cli.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from collections.abc import Sequence
 from datetime import UTC, datetime
@@ -28,9 +29,27 @@ EXIT_ERROR = 1
 EXIT_CANCELLED = 130
 
 
+LAUNCH_PROGRAMS = ("claude", "codex", "pi")
+
+
+def _launch_args(argv: Sequence[str]) -> argparse.Namespace | None:
+    """`atm claude …` 不走 argparse。
+
+    REMAINDER 有个老毛病：第一个位置参数之前的 `--xxx` 仍会被当成 atm 自己的选项解析，
+    `atm claude --resume x` 会报 unrecognized arguments。这里在 parse 之前把它截下来，
+    程序名后面的每一个字节都原样归 claude / codex / pi。
+    """
+    if argv and argv[0] in LAUNCH_PROGRAMS:
+        return argparse.Namespace(handler=_cmd_launch, program=argv[0], args=list(argv[1:]))
+    return None
+
+
 def main(argv: Sequence[str] | None = None) -> int:
-    parser = _build_parser()
-    args = parser.parse_args(argv)
+    raw = list(sys.argv[1:] if argv is None else argv)
+    args = _launch_args(raw)
+    if args is None:
+        parser = _build_parser()
+        args = parser.parse_args(raw)
     try:
         return args.handler(args)
     except (DispatchError, ValueError) as exc:
@@ -63,6 +82,18 @@ def _persist_mod():
     from . import persist
 
     return persist
+
+
+def _config_mod():
+    from . import config
+
+    return config
+
+
+def _guard_mod():
+    from . import guard
+
+    return guard
 
 
 def _sidebar_mod():
@@ -117,16 +148,8 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="不给会话套 cgroup 内存闸门（默认套）",
     )
-    p_pick.add_argument(
-        "--mem-high",
-        default=dispatch_mod.DEFAULT_MEMORY_HIGH,
-        help=f"软上限，超了节流+回收不杀（默认 {dispatch_mod.DEFAULT_MEMORY_HIGH}）",
-    )
-    p_pick.add_argument(
-        "--mem-max",
-        default=dispatch_mod.DEFAULT_MEMORY_MAX,
-        help=f"硬上限，回收压不住才杀（默认 {dispatch_mod.DEFAULT_MEMORY_MAX}）",
-    )
+    p_pick.add_argument("--mem-high", help="软上限，超了节流+回收不杀（默认取 atm config）")
+    p_pick.add_argument("--mem-max", help="硬上限，回收压不住才杀（默认取 atm config）")
     p_pick.set_defaults(handler=_cmd_pick)
 
     p_resume = sub.add_parser("resume", help="按 id 直接投递（不进 TUI）")
@@ -143,16 +166,8 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="不给会话套 cgroup 内存闸门（默认套）",
     )
-    p_resume.add_argument(
-        "--mem-high",
-        default=dispatch_mod.DEFAULT_MEMORY_HIGH,
-        help=f"软上限，超了节流+回收不杀（默认 {dispatch_mod.DEFAULT_MEMORY_HIGH}）",
-    )
-    p_resume.add_argument(
-        "--mem-max",
-        default=dispatch_mod.DEFAULT_MEMORY_MAX,
-        help=f"硬上限，回收压不住才杀（默认 {dispatch_mod.DEFAULT_MEMORY_MAX}）",
-    )
+    p_resume.add_argument("--mem-high", help="软上限，超了节流+回收不杀（默认取 atm config）")
+    p_resume.add_argument("--mem-max", help="硬上限，回收压不住才杀（默认取 atm config）")
     p_resume.set_defaults(handler=_cmd_resume, source=None, cwd=None, here=False)
 
     p_index = sub.add_parser("index", help="构建/查看索引")
@@ -180,8 +195,8 @@ def _build_parser() -> argparse.ArgumentParser:
     p_sidebar.add_argument(
         "--no-mem-limit", action="store_true", help="从侧栏恢复历史时不套内存闸门"
     )
-    p_sidebar.add_argument("--mem-high", default=dispatch_mod.DEFAULT_MEMORY_HIGH)
-    p_sidebar.add_argument("--mem-max", default=dispatch_mod.DEFAULT_MEMORY_MAX)
+    p_sidebar.add_argument("--mem-high", help="默认取 atm config")
+    p_sidebar.add_argument("--mem-max", help="默认取 atm config")
     p_sidebar.set_defaults(handler=_cmd_sidebar)
 
     p_swap = sub.add_parser("swap", help="把某个 pane 换进当前 window 的主格（不进 TUI）")
@@ -227,7 +242,44 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="不装 tmux-resurrect / tmux-continuum（默认一起装，重启后能恢复窗口布局）",
     )
+    p_install.add_argument(
+        "--no-slice",
+        action="store_true",
+        help="不写总量闸门的 systemd slice（默认写 ~/.config/systemd/user/atm-ai.slice）",
+    )
     p_install.set_defaults(handler=_cmd_install)
+
+    p_config = sub.add_parser(
+        "config",
+        help="查看 / 修改用户配置（内存闸门参数）。不带参数就是查看",
+        description=(
+            "atm config                       查看\n"
+            "atm config memory.high 4G        设置\n"
+            "atm config --unset memory.high   恢复默认\n"
+            "atm config --reset               全部恢复默认"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p_config.add_argument("key", nargs="?", help="配置项，如 memory.high")
+    p_config.add_argument("value", nargs="?", help="新值")
+    p_config.add_argument("--unset", metavar="KEY", help="把某项恢复默认")
+    p_config.add_argument("--reset", action="store_true", help="全部恢复默认（删掉配置文件）")
+    p_config.add_argument("--path", action="store_true", help="只打印配置文件路径")
+    p_config.set_defaults(handler=_cmd_config)
+
+    # `atm claude …` / `atm codex …` / `atm pi …`：带闸门启动。参数原样透传，
+    # 所以这里不接管 -h —— `atm claude --help` 看到的是 claude 自己的帮助。
+    for program in LAUNCH_PROGRAMS:
+        # 只为了出现在 `atm --help` 里；真正的分发在 main() 的 _launch_args 里。
+        p_launch = sub.add_parser(
+            program,
+            add_help=False,
+            help=(
+                f"按 atm config 的内存闸门启动 {program}（参数原样透传；直接敲 {program} 则不受限）"
+            ),
+        )
+        p_launch.add_argument("args", nargs=argparse.REMAINDER)
+        p_launch.set_defaults(handler=_cmd_launch, program=program)
 
     p_uninstall = sub.add_parser("uninstall", help="从 ~/.tmux.conf 里移除 atm 的绑定")
     p_uninstall.add_argument("-y", "--yes", action="store_true")
@@ -514,6 +566,9 @@ def _cmd_doctor(args: argparse.Namespace) -> int:
     print("\n== 持久化（resurrect + continuum）==")
     _report_persist(_persist_mod().status())
 
+    print("\n== 内存闸门 ==")
+    _report_guard()
+
     print("\n== 索引 ==")
     result = index_mod.build()
     print(f"  {result.stats.describe()}")
@@ -568,7 +623,27 @@ def _cmd_install(args: argparse.Namespace) -> int:
 
     if persist_plan is not None:
         _apply_persist(persist_plan)
+    if not args.no_slice:
+        _apply_slice()
     return EXIT_OK
+
+
+def _apply_slice() -> None:
+    guard = _guard_mod()
+    cfg = _config_mod().load()
+    if not dispatch_mod.memory_limits_available():
+        print("\n这台机器拿不到 cgroup，跳过总量闸门 slice。")
+        return
+    path, written = guard.install(cfg.memory_slice)
+    st = guard.status(cfg.memory_slice)
+    if written:
+        print(
+            f"\n已写总量闸门 {path}"
+            f"（MemoryHigh={st.high} / MemoryMax={st.max}，按物理内存 50% / 65%）"
+        )
+        print("所有 atm 启动 / 投递的会话共同受这个总量约束；单个会话的上限看 `atm config`。")
+    else:
+        print(f"\n总量闸门 {path} 已存在（MemoryHigh={st.high} / MemoryMax={st.max}），不动。")
 
 
 def _apply_persist(plan) -> None:
@@ -590,6 +665,62 @@ def _apply_persist(plan) -> None:
         print("（刻意不自动 source —— 那会重跑你整份配置里带副作用的行）")
     print("手动存/恢复：prefix + Ctrl-s / prefix + Ctrl-r；")
     print("自动存档每 10 分钟，只在有客户端 attach 时触发")
+
+
+def _cmd_config(args: argparse.Namespace) -> int:
+    config = _config_mod()
+    if args.path:
+        print(config.config_path())
+        return EXIT_OK
+    if args.reset:
+        path = config.config_path()
+        if path.exists():
+            path.unlink()
+            print(f"已删 {path}，全部恢复默认")
+        else:
+            print("本来就是默认，没有配置文件")
+        return EXIT_OK
+    try:
+        cfg = config.load()
+        if args.unset:
+            cfg = config.unset_value(cfg, args.unset)
+            path = config.save(cfg)
+            print(f"{args.unset} 已恢复默认 → {path}")
+            return EXIT_OK
+        if args.key and args.value is None:
+            raise config.ConfigError(f"要给 {args.key} 一个值，比如 `atm config {args.key} 4G`")
+        if args.key:
+            cfg = config.set_value(cfg, args.key, args.value)
+            path = config.save(cfg)
+            print(f"{args.key} = {args.value} → {path}")
+            return EXIT_OK
+    except config.ConfigError as exc:
+        print(f"atm: {exc}", file=sys.stderr)
+        return EXIT_ERROR
+    print(config.describe(cfg))
+    return EXIT_OK
+
+
+def _cmd_launch(args: argparse.Namespace) -> int:
+    """`atm claude …`：套上闸门后 exec 过去。进程被替换，退出码和 tty 都是 claude 自己的。"""
+    config = _config_mod()
+    program = args.program
+    found = config.resolve_program(program)
+    if found is None:
+        print(f"atm: PATH 里没有 {program}", file=sys.stderr)
+        return EXIT_ERROR
+    try:
+        cfg = config.load()
+    except config.ConfigError as exc:
+        print(f"atm: {exc}", file=sys.stderr)
+        return EXIT_ERROR
+    argv = config.launch_argv(found, list(args.args), cfg)
+    if argv[0] != found and config.resolve_program(argv[0]) is None:
+        # systemd-run 不在 PATH 上（非 systemd 环境）：退回裸跑，但要说一声，别让人以为限了。
+        print(f"atm: 找不到 {argv[0]}，本次不套内存闸门", file=sys.stderr)
+        argv = [found, *args.args]
+    os.execvp(argv[0], argv)
+    return EXIT_ERROR  # execvp 成功不会回来
 
 
 def _cmd_uninstall(args: argparse.Namespace) -> int:
@@ -614,6 +745,9 @@ def _cmd_uninstall(args: argparse.Namespace) -> int:
         print(f"已从 {conf_path} 移除持久化块（~/.tmux/plugins 里已克隆的插件没动，不要了自己 rm）")
         if backup_persist:
             print(f"备份 {backup_persist}")
+    slice_name = _config_mod().load().memory_slice
+    if _guard_mod().remove(slice_name):
+        print(f"已删总量闸门 {slice_name}（只删 atm 自己写的那份）")
     return EXIT_OK
 
 
@@ -630,6 +764,39 @@ def _confirm(prompt: str) -> bool:
 
 
 # ---------------------------------------------------------------- helpers
+
+
+def _report_guard() -> None:
+    config = _config_mod()
+    guard = _guard_mod()
+    try:
+        cfg = config.load()
+    except config.ConfigError as exc:
+        print(f"  ❌ {exc}")
+        return
+    if not dispatch_mod.memory_limits_available():
+        print(
+            "  cgroup: 不可用（无 systemd user manager 或 memory 控制器未 delegate）"
+            "—— 一切限制被忽略"
+        )
+        return
+    if not cfg.memory_enabled:
+        print("  已关闭（memory.enabled=false）")
+        return
+    print(
+        f"  单会话: MemoryHigh={cfg.memory_high} MemoryMax={cfg.memory_max}"
+        "（atm claude / 投递时套）"
+    )
+    st = guard.status(cfg.memory_slice)
+    if st.exists:
+        who = "atm 写的" if st.ours else "用户自己的"
+        print(f"  总量 {st.name}: MemoryHigh={st.high} MemoryMax={st.max}（{who}）")
+    else:
+        print(
+            f"  总量 {st.name}: ❌ 单元不存在 —— systemd 会建一个无限制的同名 slice，"
+            "总量闸门形同虚设。跑 atm install 补上"
+        )
+    print("  直接敲 claude / codex 不受以上任何限制；要限就用 atm claude / atm codex")
 
 
 def _report_persist(st) -> None:
@@ -782,11 +949,14 @@ def _memory_limit(args: argparse.Namespace) -> dispatch_mod.MemoryLimit | None:
     """
     if getattr(args, "no_mem_limit", False):
         return None
-    if not dispatch_mod.memory_limits_available():
+    cfg = _config_mod().load()
+    base = cfg.memory_limit()  # 已经考虑了 memory.enabled 和机器支持
+    if base is None:
         return None
+    high = getattr(args, "mem_high", None) or base.high
+    max_ = getattr(args, "mem_max", None) or base.max
     return dispatch_mod.MemoryLimit(
-        high=getattr(args, "mem_high", dispatch_mod.DEFAULT_MEMORY_HIGH),
-        max=getattr(args, "mem_max", dispatch_mod.DEFAULT_MEMORY_MAX),
+        high=high, max=max_, swap_max=base.swap_max, slice_name=base.slice_name, user=base.user
     )
 
 

--- a/src/atm/config.py
+++ b/src/atm/config.py
@@ -1,0 +1,210 @@
+"""`atm config`：用户级配置，目前只管一件事 —— 启动 AI CLI 时套什么内存闸门。
+
+为什么要有这个文件而不是一堆命令行参数：闸门参数（MemoryHigh / MemoryMax / slice）是**这台机器**
+的属性，不是某一次投递的属性。48G 的机器和 8G 的机器该给的数字不一样，但每次 `--mem-high` 手敲
+没人会做。设一次，之后 `atm claude` / `atm pick` / 侧栏恢复全部沿用。
+
+刻意保留一条**不受限**的路：直接敲 `claude` 就是原生的，不套任何东西。
+`atm claude` 才进闸门 —— 前缀即选择，不劫持用户的命令。
+
+文件在 `~/.config/atm/config.toml`（尊重 `$XDG_CONFIG_HOME`，测试用 `$ATM_CONFIG` 指到别处）。
+只读用 stdlib `tomllib`；写用一个几十行的扁平 TOML 写手 —— 这里只有字符串和布尔，
+不值得为此引入依赖（零运行时依赖是本项目的硬约束）。
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import tomllib
+from dataclasses import dataclass, fields, replace
+from pathlib import Path
+
+from . import dispatch
+
+# systemd 认的内存大小：纯数字（字节）或带 K/M/G/T 后缀；`infinity` 表示不限。
+_SIZE_RE = re.compile(r"^(\d+(\.\d+)?[KMGT]?|infinity)$", re.IGNORECASE)
+_TRUE = {"1", "true", "yes", "on"}
+_FALSE = {"0", "false", "no", "off"}
+
+
+def config_path() -> Path:
+    override = os.environ.get("ATM_CONFIG")
+    if override:
+        return Path(override).expanduser()
+    base = os.environ.get("XDG_CONFIG_HOME")
+    root = Path(base).expanduser() if base else Path.home() / ".config"
+    return root / "atm" / "config.toml"
+
+
+@dataclass(frozen=True, slots=True)
+class Config:
+    """所有字段都有默认值，缺文件 = 全默认。默认值和 dispatch 里的常量保持同一来源。"""
+
+    memory_enabled: bool = True
+    memory_high: str = dispatch.DEFAULT_MEMORY_HIGH
+    memory_max: str = dispatch.DEFAULT_MEMORY_MAX
+    memory_swap_max: str = dispatch.DEFAULT_MEMORY_SWAP_MAX
+    memory_slice: str = dispatch.DEFAULT_SLICE
+    # systemd-run 走 `--user`（当前用户的 user manager）。关掉就是系统级 scope，需要 root，
+    # 一般人用不到，留着是因为有人在容器 / 服务器上确实是 root 跑的。
+    memory_user: bool = True
+
+    def memory_limit(self) -> dispatch.MemoryLimit | None:
+        """按配置生成闸门；关了或机器不支持就是 None（= 不套）。"""
+        if not self.memory_enabled or not dispatch.memory_limits_available():
+            return None
+        return dispatch.MemoryLimit(
+            high=self.memory_high,
+            max=self.memory_max,
+            swap_max=self.memory_swap_max,
+            slice_name=self.memory_slice,
+            user=self.memory_user,
+        )
+
+
+# 命令行上的 key（点号分段） → dataclass 字段 → 校验器
+KEYS: dict[str, str] = {
+    "memory.enabled": "memory_enabled",
+    "memory.high": "memory_high",
+    "memory.max": "memory_max",
+    "memory.swap-max": "memory_swap_max",
+    "memory.slice": "memory_slice",
+    "memory.user": "memory_user",
+}
+
+_HELP: dict[str, str] = {
+    "memory.enabled": "要不要套闸门（true/false）",
+    "memory.high": "软上限：超了节流 + 回收，不杀（如 4G）",
+    "memory.max": "硬上限：回收压不住才杀，杀的是整个会话及其子进程（如 8G）",
+    "memory.swap-max": "swap 上限（WSL 上 swap 在宿主 SSD，建议小）",
+    "memory.slice": "所有会话共同归入的 systemd slice，兜总量",
+    "memory.user": "systemd-run 是否走 --user（一般 true）",
+}
+
+
+class ConfigError(ValueError):
+    pass
+
+
+def load(path: Path | None = None) -> Config:
+    """读配置。文件不存在 → 默认；文件坏了 → 抛 ConfigError 而不是静默用默认值，
+    否则用户以为限制生效了其实没有。"""
+    p = path or config_path()
+    try:
+        raw = tomllib.loads(p.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return Config()
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise ConfigError(f"{p} 读不了：{exc}") from exc
+    cfg = Config()
+    for key, field in KEYS.items():
+        section, name = key.split(".", 1)
+        value = (raw.get(section) or {}).get(name.replace("-", "_"))
+        if value is not None:
+            cfg = replace(cfg, **{field: _coerce(key, value)})
+    return cfg
+
+
+def save(cfg: Config, path: Path | None = None) -> Path:
+    p = path or config_path()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(dumps(cfg), encoding="utf-8")
+    return p
+
+
+def set_value(cfg: Config, key: str, value: str) -> Config:
+    """校验并返回新配置。key 不认识 / 值不合法都抛 ConfigError，带可读原因。"""
+    field = KEYS.get(key)
+    if field is None:
+        raise ConfigError(f"不认识的配置项 {key!r}，可用：{', '.join(KEYS)}")
+    return replace(cfg, **{field: _coerce(key, value)})
+
+
+def unset_value(cfg: Config, key: str) -> Config:
+    field = KEYS.get(key)
+    if field is None:
+        raise ConfigError(f"不认识的配置项 {key!r}，可用：{', '.join(KEYS)}")
+    return replace(cfg, **{field: getattr(Config(), field)})
+
+
+def describe(cfg: Config) -> str:
+    """`atm config` 不带参数时的输出：值 + 是否默认 + 一句说明。"""
+    default = Config()
+    lines = [
+        f"配置文件：{config_path()}{'' if config_path().exists() else '（不存在，全部默认）'}",
+        "",
+    ]
+    for key, field in KEYS.items():
+        value = getattr(cfg, field)
+        shown = str(value).lower() if isinstance(value, bool) else value
+        tag = "" if value == getattr(default, field) else "  ← 已设置"
+        lines.append(f"  {key:<16} {shown:<12}{tag}")
+        lines.append(f"  {'':<16} {_HELP[key]}")
+    lines.append("")
+    if not dispatch.memory_limits_available():
+        lines.append(
+            "⚠ 这台机器拿不到 cgroup（无 systemd user manager 或 memory 控制器未 delegate），"
+        )
+        lines.append("  以上设置会被静默忽略，atm claude 等价于直接跑 claude。")
+    return "\n".join(lines)
+
+
+def dumps(cfg: Config) -> str:
+    """扁平 TOML：一个 [memory] 表，字符串和布尔。不支持别的类型，也不需要。"""
+    lines = [
+        "# atm 的用户配置。改完立即生效，不用重启。",
+        "# `atm config` 查看，`atm config <key> <value>` 修改。",
+        "",
+        "[memory]",
+    ]
+    for key, field in KEYS.items():
+        name = key.split(".", 1)[1].replace("-", "_")
+        value = getattr(cfg, field)
+        if isinstance(value, bool):
+            lines.append(f"{name} = {'true' if value else 'false'}")
+        else:
+            lines.append(f'{name} = "{value}"')
+    return "\n".join(lines) + "\n"
+
+
+def _coerce(key: str, value: object):
+    field = KEYS[key]
+    kind = next(f.type for f in fields(Config) if f.name == field)
+    if kind == "bool":
+        if isinstance(value, bool):
+            return value
+        s = str(value).strip().lower()
+        if s in _TRUE:
+            return True
+        if s in _FALSE:
+            return False
+        raise ConfigError(f"{key} 要 true/false，收到 {value!r}")
+    s = str(value).strip()
+    if key == "memory.slice":
+        if not re.match(r"^[\w.-]+\.slice$", s):
+            raise ConfigError(f"{key} 要形如 name.slice，收到 {value!r}")
+        return s
+    if not _SIZE_RE.match(s):
+        raise ConfigError(f"{key} 要形如 4G / 512M / infinity，收到 {value!r}")
+    return s.upper() if s != "infinity" else s
+
+
+# ---------------------------------------------------------------- 启动包装
+
+
+def launch_argv(program: str, args: list[str], cfg: Config) -> list[str]:
+    """`atm claude …` 真正 exec 的 argv。有闸门就裹 systemd-run，没有就是原样。
+
+    纯函数，不查 PATH、不 exec，好测。
+    """
+    limit = cfg.memory_limit()
+    if limit is None:
+        return [program, *args]
+    return [*limit.systemd_args(f"atm: {program}"), program, *args]
+
+
+def resolve_program(program: str) -> str | None:
+    """PATH 上找可执行文件。找不到返回 None，让调用方给人话。"""
+    return shutil.which(program)

--- a/src/atm/dispatch.py
+++ b/src/atm/dispatch.py
@@ -119,11 +119,13 @@ class MemoryLimit:
     max: str = DEFAULT_MEMORY_MAX
     swap_max: str = DEFAULT_MEMORY_SWAP_MAX
     slice_name: str = DEFAULT_SLICE
+    # False = 系统级 scope（需要 root）。默认走当前用户的 user manager。
+    user: bool = True
 
     def systemd_args(self, description: str) -> list[str]:
         return [
             "systemd-run",
-            "--user",
+            *(["--user"] if self.user else []),
             "--scope",
             "-q",
             f"--slice={self.slice_name}",

--- a/src/atm/guard.py
+++ b/src/atm/guard.py
@@ -1,0 +1,138 @@
+"""总量闸门：所有 `atm claude` / 投递出去的会话共同归入的 systemd slice。
+
+单进程闸门（MemoryHigh / Max，见 dispatch.py）拦的是「一个会话自己失控」；
+真正把机器冻死的是**总量** —— 8 月那次事故是 4 个会话合计吃掉 87% 内存。
+所以每个会话的 scope 都挂在同一个 slice 下，slice 上再设一层 High / Max 兜总量。
+
+dispatch.py 一直假定这个 slice「由用户环境提供」，但从没有人去提供 —— 单元文件躺在
+research/experiments/2026-08-12-memory-slice/ 里，机器上并没有。slice 不存在时 systemd 会
+自动建一个**无限制**的同名 slice，投递不会失败，只是总量闸门形同虚设。这个模块把它补上：
+`atm install` 写 `~/.config/systemd/user/<slice>`，`atm doctor` 查它在不在、限制多少。
+
+数值按机器算：软限 50% 物理内存、硬限 65%。8G 的机器是 4G / 5G（和 8 月那份手写的一致），
+48G 的机器是 24G / 31G。写死一个数对两种机器都不对。
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+HEADER = "# 由 atm install 生成；atm uninstall 会删掉它。手改无妨，但请去掉这一行，否则会被卸载。"
+HIGH_RATIO = 0.50
+MAX_RATIO = 0.65
+
+
+def unit_dir() -> Path:
+    base = os.environ.get("XDG_CONFIG_HOME")
+    root = Path(base).expanduser() if base else Path.home() / ".config"
+    return root / "systemd" / "user"
+
+
+def total_memory_bytes(meminfo: Path = Path("/proc/meminfo")) -> int | None:
+    try:
+        for line in meminfo.read_text().splitlines():
+            if line.startswith("MemTotal:"):
+                return int(line.split()[1]) * 1024
+    except (OSError, ValueError, IndexError):
+        pass
+    return None
+
+
+def suggested_totals(total_bytes: int) -> tuple[str, str]:
+    """(MemoryHigh, MemoryMax)，按 GiB 取整，最小 1G。"""
+    gib = 1 << 30
+    high = max(1, round(total_bytes * HIGH_RATIO / gib))
+    hard = max(high + 1, round(total_bytes * MAX_RATIO / gib))
+    return f"{high}G", f"{hard}G"
+
+
+def unit_text(*, high: str, max_: str, swap_max: str = "1G") -> str:
+    return (
+        "\n".join(
+            (
+                HEADER,
+                "[Unit]",
+                "Description=atm: aggregate memory guard for AI CLI sessions",
+                "Documentation=https://github.com/lyfuci/ai-terminal-manager/blob/main/docs/reference.md",
+                "",
+                "[Slice]",
+                "MemoryAccounting=yes",
+                "# 软限：超了强回收 + 节流，不杀。",
+                f"MemoryHigh={high}",
+                "# 硬限：到这里才杀。宁可掉一个会话，也不要整机冻死。",
+                f"MemoryMax={max_}",
+                f"MemorySwapMax={swap_max}",
+            )
+        )
+        + "\n"
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class SliceStatus:
+    name: str
+    path: Path
+    exists: bool
+    ours: bool
+    high: str | None
+    max: str | None
+
+
+def status(slice_name: str, directory: Path | None = None) -> SliceStatus:
+    path = (directory or unit_dir()) / slice_name
+    exists = path.exists()
+    ours = False
+    high = max_ = None
+    if exists:
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            text = ""
+        ours = text.startswith(HEADER)
+        for line in text.splitlines():
+            if line.startswith("MemoryHigh="):
+                high = line.split("=", 1)[1]
+            elif line.startswith("MemoryMax="):
+                max_ = line.split("=", 1)[1]
+    return SliceStatus(slice_name, path, exists, ours, high, max_)
+
+
+def install(
+    slice_name: str, directory: Path | None = None, *, total_bytes: int | None = None
+) -> tuple[Path, bool]:
+    """写单元文件。已存在就**不动**（用户可能手调过），返回 (path, written)。"""
+    path = (directory or unit_dir()) / slice_name
+    if path.exists():
+        return path, False
+    total = total_bytes if total_bytes is not None else total_memory_bytes()
+    high, max_ = suggested_totals(total) if total else ("4G", "5G")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(unit_text(high=high, max_=max_), encoding="utf-8")
+    _daemon_reload()
+    return path, True
+
+
+def remove(slice_name: str, directory: Path | None = None) -> bool:
+    """只删我们自己写的（带 HEADER）。用户手写的一律不碰。"""
+    st = status(slice_name, directory)
+    if not (st.exists and st.ours):
+        return False
+    st.path.unlink()
+    _daemon_reload()
+    return True
+
+
+def _daemon_reload() -> None:
+    if shutil.which("systemctl") is None:
+        return
+    subprocess.run(
+        ["systemctl", "--user", "daemon-reload"],
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,267 @@
+"""`atm config` + `atm claude …` 启动包装 + 总量闸门 slice。
+
+配置文件一律通过 ATM_CONFIG 指到 tmp_path；slice 单元写到 tmp_path；
+systemd-run / systemctl 一律不真跑。
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+from atm import cli, config, dispatch, guard
+
+
+@pytest.fixture
+def cfg_path(tmp_path: Path, monkeypatch) -> Path:
+    p = tmp_path / "atm" / "config.toml"
+    monkeypatch.setenv("ATM_CONFIG", str(p))
+    return p
+
+
+@pytest.fixture
+def cgroup_ok(monkeypatch):
+    monkeypatch.setattr(dispatch, "memory_limits_available", lambda: True)
+
+
+# ---------------------------------------------------------------- 读写
+
+
+def test_missing_file_is_all_defaults(cfg_path: Path) -> None:
+    cfg = config.load()
+    assert cfg == config.Config()
+    assert cfg.memory_high == dispatch.DEFAULT_MEMORY_HIGH
+
+
+def test_set_save_load_roundtrip(cfg_path: Path) -> None:
+    cfg = config.set_value(config.Config(), "memory.high", "4g")
+    cfg = config.set_value(cfg, "memory.max", "8G")
+    cfg = config.set_value(cfg, "memory.user", "false")
+    config.save(cfg)
+
+    loaded = config.load()
+    assert loaded.memory_high == "4G"  # 大小写归一
+    assert loaded.memory_max == "8G"
+    assert loaded.memory_user is False
+    assert loaded.memory_enabled is True  # 没动的保持默认
+
+
+def test_unset_restores_default(cfg_path: Path) -> None:
+    cfg = config.set_value(config.Config(), "memory.high", "4G")
+    cfg = config.unset_value(cfg, "memory.high")
+    assert cfg.memory_high == dispatch.DEFAULT_MEMORY_HIGH
+
+
+@pytest.mark.parametrize(
+    ("key", "bad"),
+    [
+        ("memory.high", "4 gigs"),
+        ("memory.max", "-1G"),
+        ("memory.enabled", "maybe"),
+        ("memory.slice", "no-suffix"),
+        ("memory.nope", "1"),
+    ],
+)
+def test_invalid_values_rejected(key: str, bad: str) -> None:
+    with pytest.raises(config.ConfigError):
+        config.set_value(config.Config(), key, bad)
+
+
+def test_infinity_allowed() -> None:
+    cfg = config.set_value(config.Config(), "memory.max", "infinity")
+    assert cfg.memory_max == "infinity"
+
+
+def test_corrupt_file_raises_not_silently_defaults(cfg_path: Path) -> None:
+    """配置坏了要报错。静默回默认会让人以为限制生效了其实没有。"""
+    cfg_path.parent.mkdir(parents=True)
+    cfg_path.write_text("[memory\nhigh = ", encoding="utf-8")
+    with pytest.raises(config.ConfigError):
+        config.load()
+
+
+def test_dumps_is_valid_toml_and_flat() -> None:
+    import tomllib
+
+    text = config.dumps(config.Config(memory_high="3G", memory_user=False))
+    data = tomllib.loads(text)
+    assert data["memory"]["high"] == "3G"
+    assert data["memory"]["user"] is False
+    assert data["memory"]["swap_max"] == dispatch.DEFAULT_MEMORY_SWAP_MAX
+
+
+# ---------------------------------------------------------------- 闸门 → argv
+
+
+def test_memory_limit_none_when_disabled(cgroup_ok) -> None:
+    assert config.Config(memory_enabled=False).memory_limit() is None
+
+
+def test_memory_limit_none_when_cgroup_unavailable(monkeypatch) -> None:
+    monkeypatch.setattr(dispatch, "memory_limits_available", lambda: False)
+    assert config.Config().memory_limit() is None
+
+
+def test_launch_argv_wraps_with_systemd_run(cgroup_ok) -> None:
+    cfg = config.Config(memory_high="4G", memory_max="8G")
+    argv = config.launch_argv("/usr/bin/claude", ["--resume", "abc"], cfg)
+    assert argv[0] == "systemd-run"
+    assert "--user" in argv
+    assert "MemoryHigh=4G" in argv
+    assert "MemoryMax=8G" in argv
+    assert f"--slice={dispatch.DEFAULT_SLICE}" in argv
+    # 程序和参数在最后，原样透传
+    assert argv[-3:] == ["/usr/bin/claude", "--resume", "abc"]
+
+
+def test_launch_argv_plain_when_disabled(cgroup_ok) -> None:
+    cfg = config.Config(memory_enabled=False)
+    assert config.launch_argv("/usr/bin/codex", ["resume", "x"], cfg) == [
+        "/usr/bin/codex",
+        "resume",
+        "x",
+    ]
+
+
+def test_launch_argv_system_scope_drops_user_flag(cgroup_ok) -> None:
+    argv = config.launch_argv("/usr/bin/pi", [], config.Config(memory_user=False))
+    assert "--user" not in argv
+    assert argv[0] == "systemd-run"
+
+
+# ---------------------------------------------------------------- cli 接线
+
+
+def test_launch_args_pass_everything_through_untouched() -> None:
+    """`atm claude --resume x -p y`：程序名之后的每个字节都是 claude 的，包括长得像 atm 选项的。"""
+    ns = cli._launch_args(["claude", "--resume", "abc", "-p", "hello", "--no-mem-limit"])
+    assert ns is not None
+    assert ns.program == "claude"
+    assert ns.args == ["--resume", "abc", "-p", "hello", "--no-mem-limit"]
+    assert ns.handler is cli._cmd_launch
+
+
+def test_launch_args_help_goes_to_program_not_atm() -> None:
+    ns = cli._launch_args(["codex", "--help"])
+    assert ns is not None and ns.args == ["--help"]
+
+
+def test_launch_args_ignores_other_commands() -> None:
+    assert cli._launch_args(["list", "-n", "3"]) is None
+    assert cli._launch_args([]) is None
+
+
+def test_main_routes_launch_before_argparse(cfg_path: Path, cgroup_ok, monkeypatch) -> None:
+    calls: list[list[str]] = []
+    monkeypatch.setattr(config, "resolve_program", lambda name: f"/bin/{name}")
+    monkeypatch.setattr(cli.os, "execvp", lambda file, argv: calls.append(list(argv)))
+    cli.main(["pi", "--session", "abc", "--help"])
+    assert calls and calls[0][-4:] == ["/bin/pi", "--session", "abc", "--help"]
+
+
+def test_memory_limit_falls_back_to_config(cfg_path: Path, cgroup_ok) -> None:
+    config.save(config.set_value(config.Config(), "memory.high", "6G"))
+    ns = argparse.Namespace(no_mem_limit=False, mem_high=None, mem_max=None)
+    limit = cli._memory_limit(ns)
+    assert limit is not None
+    assert limit.high == "6G"
+    assert limit.max == dispatch.DEFAULT_MEMORY_MAX
+
+
+def test_memory_limit_cli_flag_beats_config(cfg_path: Path, cgroup_ok) -> None:
+    config.save(config.set_value(config.Config(), "memory.high", "6G"))
+    ns = argparse.Namespace(no_mem_limit=False, mem_high="1G", mem_max=None)
+    assert cli._memory_limit(ns).high == "1G"
+
+
+def test_memory_limit_respects_disabled_config(cfg_path: Path, cgroup_ok) -> None:
+    config.save(config.set_value(config.Config(), "memory.enabled", "false"))
+    ns = argparse.Namespace(no_mem_limit=False, mem_high=None, mem_max=None)
+    assert cli._memory_limit(ns) is None
+
+
+def test_launch_execs_wrapped_argv(cfg_path: Path, cgroup_ok, monkeypatch) -> None:
+    calls: list[list[str]] = []
+    monkeypatch.setattr(config, "resolve_program", lambda name: f"/bin/{name}")
+    monkeypatch.setattr(cli.os, "execvp", lambda file, argv: calls.append([file, *argv[1:]]))
+    ns = argparse.Namespace(program="claude", args=["--resume", "id1"])
+    cli._cmd_launch(ns)
+    assert calls and calls[0][0] == "systemd-run"
+    assert calls[0][-3:] == ["/bin/claude", "--resume", "id1"]
+
+
+def test_launch_missing_program_is_an_error(cfg_path: Path, monkeypatch, capsys) -> None:
+    monkeypatch.setattr(config, "resolve_program", lambda name: None)
+    ns = argparse.Namespace(program="pi", args=[])
+    assert cli._cmd_launch(ns) == cli.EXIT_ERROR
+    assert "PATH 里没有 pi" in capsys.readouterr().err
+
+
+def test_launch_without_systemd_run_falls_back_to_plain(
+    cfg_path: Path, cgroup_ok, monkeypatch, capsys
+) -> None:
+    monkeypatch.setattr(
+        config, "resolve_program", lambda n: None if n == "systemd-run" else f"/bin/{n}"
+    )
+    calls: list[list[str]] = []
+    monkeypatch.setattr(cli.os, "execvp", lambda file, argv: calls.append(list(argv)))
+    cli._cmd_launch(argparse.Namespace(program="claude", args=["x"]))
+    assert calls == [["/bin/claude", "x"]]
+    assert "不套内存闸门" in capsys.readouterr().err
+
+
+def test_config_command_set_and_show(cfg_path: Path, capsys) -> None:
+    assert cli.main(["config", "memory.high", "5G"]) == cli.EXIT_OK
+    assert cli.main(["config"]) == cli.EXIT_OK
+    out = capsys.readouterr().out
+    assert "memory.high" in out and "5G" in out and "已设置" in out
+
+
+def test_config_command_rejects_garbage(cfg_path: Path, capsys) -> None:
+    assert cli.main(["config", "memory.high", "lots"]) == cli.EXIT_ERROR
+    assert "memory.high" in capsys.readouterr().err
+    assert not cfg_path.exists()  # 没写坏东西进去
+
+
+# ---------------------------------------------------------------- 总量闸门 slice
+
+
+def test_suggested_totals_scale_with_ram() -> None:
+    gib = 1 << 30
+    assert guard.suggested_totals(8 * gib) == ("4G", "5G")  # 和 8 月手写的那份一致
+    assert guard.suggested_totals(48 * gib) == ("24G", "31G")
+    high, max_ = guard.suggested_totals(1 * gib)
+    assert int(high[:-1]) < int(max_[:-1])  # 再小也保证 High < Max
+
+
+def test_slice_install_writes_once_and_never_overwrites(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(guard, "_daemon_reload", lambda: None)
+    path, written = guard.install("atm-ai.slice", tmp_path, total_bytes=16 << 30)
+    assert written and path.exists()
+    st = guard.status("atm-ai.slice", tmp_path)
+    assert st.ours and st.high == "8G" and st.max == "10G"
+
+    path.write_text("[Slice]\nMemoryHigh=1G\n", encoding="utf-8")  # 用户手改
+    _, written_again = guard.install("atm-ai.slice", tmp_path, total_bytes=16 << 30)
+    assert not written_again
+    assert guard.status("atm-ai.slice", tmp_path).high == "1G"
+
+
+def test_slice_remove_only_touches_ours(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(guard, "_daemon_reload", lambda: None)
+    theirs = tmp_path / "atm-ai.slice"
+    theirs.write_text("[Slice]\nMemoryHigh=1G\n", encoding="utf-8")
+    assert guard.remove("atm-ai.slice", tmp_path) is False
+    assert theirs.exists()
+
+    theirs.unlink()
+    guard.install("atm-ai.slice", tmp_path, total_bytes=8 << 30)
+    assert guard.remove("atm-ai.slice", tmp_path) is True
+    assert not theirs.exists()
+
+
+def test_slice_status_when_missing(tmp_path: Path) -> None:
+    st = guard.status("atm-ai.slice", tmp_path)
+    assert not st.exists and not st.ours and st.high is None

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "ai-terminal-manager"
-version = "0.1.1"
+version = "0.2.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## 动机

手动在 tmux 里敲 `claude` / `codex` 的进程落在 tmux 自己的 `tmux-spawn-*.scope` 里，`memory.max=max`，零限制；atm 的单进程闸门只覆盖 `prefix + a` 投递这一条路；总量闸门 `atm-ai.slice` 从来没被装过（`dispatch.py` 假定"由用户环境提供"，但没人提供）。

用户要的形态：**设一次，`atm claude` 就带上；不带前缀的 `claude` 保持原生不受限**。

## 改动摘要

- **`atm config`**：`~/.config/atm/config.toml`，`memory.enabled / high / max / swap-max / slice / user`，带校验、`--unset` / `--reset` / `--path`。配置坏了报错不静默
- **`atm claude …` / `atm codex …` / `atm pi …`**：按配置套 `systemd-run --user --scope --slice=atm-ai.slice -p MemoryHigh -p MemoryMax` 后 `exec`。程序名后的一切原样透传（含 `--help`）——在 `main()` 里于 argparse 之前截下，绕开 REMAINDER 把首位置参数前的 `--xxx` 当 atm 选项的老毛病
- `pick` / `resume` / 侧栏的 `--mem-high` / `--mem-max` 默认取 atm config
- **`guard.py`**：`atm install` 写总量闸门 `~/.config/systemd/user/atm-ai.slice`（按物理内存 50% / 65%；已存在不动），`atm uninstall` 只删自己写的；`--no-slice` 跳过
- **`atm doctor`** 新增内存闸门段
- `MemoryLimit.user`（false = 系统级 scope）
- 文档：reference 内存闸门段重写为两层；usage ×3 加一节；README ×3 加一句。版本 0.2.0

## 验证方式

- 275 passed（新增 `tests/test_config.py` 28 条：读写/校验/argv/路由/slice，不真跑 systemd）；ruff 干净；文档链接无失效
- 本机实测：`atm config memory.high 4G` → `atm claude --version` 正常；用 `sleep` 替身确认进程 cgroup 为 `atm.slice/atm-ai.slice/run-uNN.scope`，`memory.high=4294967296 memory.max=8589934592`
- `atm doctor` 正确报出"总量 slice 单元不存在"（本机尚未跑新版 `atm install`）

## 合并后

`uv tool upgrade ai-terminal-manager`（发版后）或 `uv tool install --reinstall git+…`，然后 `atm install` 补 slice、`atm config memory.high 4G` / `memory.max 8G`（48G 机器的合理值）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
