### PR TITLE
docs: AGENTS.md + Claude skills，agent 进仓库直接知道怎么干活

### DIFF
--- a/.claude/skills/add-session-source/SKILL.md
+++ b/.claude/skills/add-session-source/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: add-session-source
+description: Add a new AI CLI as a session source for atm (discover + parse its on-disk sessions, resume command, display tag, doctor, launch wrapper, tests, trilingual docs). Use when asked to support another coding agent CLI such as Gemini CLI, OpenCode, Grok Build.
+---
+
+# Add a session source
+
+A "source" is one CLI whose sessions atm can list and resume. Pi (PR #5) is the reference implementation:
+`src/atm/sources/pi.py` plus the nine touch points below. Do them in this order; the two guard tests at the end
+fail until every registry is updated, which is the point.
+
+## 0. Before writing code: qualify the CLI
+
+Three conditions, all required:
+1. It runs in a terminal pane (a GUI app has no pane to swap).
+2. It writes **one file per session** on disk, and that file (or its head) carries the session id and the cwd.
+3. It has a **resume-by-id** command (`claude --resume <id>`, `codex resume <id>`, `pi --session <id>`).
+
+Find out — by reading real files if the CLI is installed, otherwise from upstream docs — and write down:
+- root directory and filename pattern; how many directory levels to scan (Claude: exactly one — recursing picks up
+  1332 sub-artefacts with no session id of their own)
+- which record carries `id` / `cwd` / `git branch`; whether they are in the file head (atm reads heads only: 198 ms
+  cold start over 1.73 GB depends on it)
+- how the display title is produced and whether it can change later in the file (Pi's `session_info` can be renamed —
+  scan the tail too)
+- which "user" messages are actually injected wrappers (`<local-command-caveat>`, `<environment_context>`, tool
+  results masquerading as user turns) and must be skipped for the title
+- the exact resume argv
+
+If the adapter is written from docs rather than observed data, **say so in the module docstring, in the PR, and in
+docs/reference.md** — Pi's adapter is marked this way.
+
+## 1. `src/atm/sources/<name>.py`
+
+Implement the two functions every adapter has:
+
+```python
+def discover(root: Path | None = None) -> Iterator[FileRef]: ...
+def parse(ref: FileRef) -> SessionEntry | None: ...
+```
+
+- `DEFAULT_ROOT` module constant; `discover(root)` must accept an override (tests pass `tmp_path`).
+- Read the head only (`_MAX_RECORDS`), then a bounded tail scan only if the format needs it.
+- Every JSON access is defensive: `.get`, isinstance checks, `continue` on garbage. Return `None` for a file that
+  yields no usable entry — never raise.
+- Filename-derived ids must be validated (`_ID_RE`); reject rather than fabricate.
+- Use `text.clean_title(...)` for titles; it strips the known injection wrappers.
+
+## 2. Registries (each one has a guard test)
+
+| File | Change |
+|---|---|
+| `src/atm/model.py` | `Source.<NAME> = "<name>"`; `SOURCE_TAG[Source.<NAME>] = "XX"` (two chars, shown in lists) |
+| `src/atm/dispatch.py` | `RESUME_PROGRAMS[Source.<NAME>] = ("<program>", "<resume-flag>")` with a comment citing where the argv came from |
+| `src/atm/index.py` | `SourceRoots.<name>_root`; the `if Source.<NAME> in wanted: ingest(...)` block; `_cached_source()` path sniff (`"/.<dir>/" in path`) |
+| `src/atm/sidebar.py` | add the program name to `AI_COMMANDS` (sidebar detects running AI panes by `pane_current_command`) |
+| `src/atm/cli.py` | `LAUNCH_PROGRAMS` (enables `atm <name> …`); `_cmd_doctor`: report the root and check the program is on PATH |
+
+## 3. Tests (`tests/`)
+
+- `conftest.py`: a `<name>_root` fixture building a synthetic corpus under `tmp_path` — never real data.
+- `test_sources.py`: discover finds files and skips the wrong depth; parse yields id/cwd/title; malformed file → `None`;
+  injected wrappers are not used as titles; late rename is picked up (if applicable); filename with a bad id is rejected.
+- The two guard tests already exist and must pass: `test_every_source_has_a_resume_command` (`test_dispatch.py`)
+  and `test_every_source_has_a_display_tag` (`test_grouping.py`).
+- `test_config.py::test_launch_args_*` cover `LAUNCH_PROGRAMS` generically; add the new name to the parametrization
+  if one exists.
+
+## 4. Docs — three languages, same commit
+
+- `README.md` / `README-cn.md` / `README-ja.md`: the "What it is" line and the Requirements bullet list the CLIs and
+  their session directories.
+- `docs/usage.md` / `-cn` / `-ja`: the `Tab` cycle list in the popup section.
+- `docs/reference.md` (Chinese): "数据来源" section — add the root, filename pattern, which record carries what,
+  the resume command, and whether it was verified on real data.
+- `research/README*.md`: the "Sidebar data sources" section gets a paragraph like Pi's.
+
+## 5. Verify
+
+```bash
+uv run --frozen ruff check . && uv run --frozen ruff format --check .
+uv run --frozen pytest
+uv run --frozen atm doctor            # new root reported; program on PATH or not
+uv run --frozen atm list --source <name> -n 5
+```
+
+If the CLI is installed, resume one real session through `atm resume <id-prefix> --print` and run the printed line
+by hand. If it is not installed, say so in the PR and ask for verification on a machine that has it.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: release
+description: Cut a release of ai-terminal-manager — bump the version in all three places, verify, tag, and let the publish workflow push to PyPI via trusted publishing. Use when asked to release, publish, bump the version, or push a new version to PyPI.
+---
+
+# Release
+
+Publishing is automatic: pushing a `v*` tag runs `.github/workflows/publish.yml` (build → PyPI trusted publishing,
+no tokens in the repo). Your job is to get `main` into a releasable state and push the tag.
+
+## 1. Version — three places, one commit
+
+```
+pyproject.toml            version = "X.Y.Z"
+src/atm/__init__.py       __version__ = "X.Y.Z"
+uv.lock                   [[package]] name = "ai-terminal-manager" / version = "X.Y.Z"   (root package only)
+```
+
+Edit `uv.lock` by hand for the version line only. Do **not** run `uv lock` to regenerate it unless dependencies
+changed — on machines with a mirror configured it rewrites every index URL.
+
+Semver: docs-only / link fixes → patch; new subcommand or flag → minor; breaking CLI or config change → major.
+
+## 2. Verify
+
+```bash
+uv run --frozen ruff check . && uv run --frozen ruff format --check .
+uv run --frozen pytest
+uv build
+python -c "import zipfile,glob; print(zipfile.ZipFile(glob.glob('dist/*.whl')[-1]).namelist())"   # atm/ only
+python -c "import tarfile,glob; print(sorted({m.name.split('/',1)[1].split('/')[0] for m in tarfile.open(glob.glob('dist/*.tar.gz')[-1]).getmembers() if '/' in m.name}))"   # no research/
+```
+
+README links must be **absolute** (`https://github.com/lyfuci/ai-terminal-manager/blob/main/...`): PyPI renders
+`README.md` as the project description and relative links 404 there. Check: `grep -nE '\]\([^)h#]' README.md` → empty.
+
+## 3. Ship
+
+The version bump goes through a PR like any change (three-section body). After it merges:
+
+```bash
+git checkout main && git pull --ff-only
+git tag -a vX.Y.Z -m "vX.Y.Z — <one line>"
+git push origin vX.Y.Z
+gh run watch $(gh run list --workflow publish --limit 1 --json databaseId -q '.[0].databaseId') --exit-status
+curl -s https://pypi.org/pypi/ai-terminal-manager/X.Y.Z/json | python -c "import json,sys; print(json.load(sys.stdin)['info']['version'])"
+```
+
+A PyPI release's description is immutable; a README mistake needs a new patch release, not a re-upload.
+
+## 4. Afterwards
+
+- Delete the merged branch (local + remote).
+- Mirrors (aliyun, tuna) lag PyPI by minutes to an hour; `uv tool install ai-terminal-manager` through a mirror may
+  fail briefly. `uv tool install git+https://github.com/lyfuci/ai-terminal-manager` works immediately.
+- The installed tool is named `ai-terminal-manager` (PyPI `atm` was taken); the command is still `atm`.
+  Upgrading from the pre-rename install: `uv tool uninstall atm` first.

--- a/.claude/skills/tmux-experiment/SKILL.md
+++ b/.claude/skills/tmux-experiment/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: tmux-experiment
+description: Run a tmux experiment or end-to-end check on a real machine without touching the user's tmux server — isolated socket, no config, cleanup, and how to drive atm against it. Use before any manual tmux verification, layout probe, or sidebar/dispatch test outside pytest.
+---
+
+# tmux experiments on a real machine
+
+Two things went wrong in this repo's history, both from experiments touching the user's real server:
+
+1. A test server started with `-L name` but without `-f /dev/null` sourced `~/.tmux.conf`; `@continuum-restore on`
+   restored the user's **entire saved layout** into the test server — five `claude` processes launched at once.
+2. A stray experiment socket was still around when the user's main server restarted; tmux-continuum saw "another
+   server running" and **silently skipped installing its autosave hook**. Nothing was saved for 9 h 40 min.
+
+So the ritual is not optional.
+
+## Start
+
+```bash
+NAME=exp-$(date +%s)
+tmux -L "$NAME" -f /dev/null new-session -d -x 160 -y 50
+```
+
+- `-L` isolates the socket; `-f /dev/null` stops it sourcing the user's config. **Both.**
+- If you need atm's key bindings, run `TMUX="$(tmux -L "$NAME" display -p '#{socket_path}'),0,0" bash atm.tmux`
+  instead of sourcing the user's config.
+
+## Drive atm against the isolated server
+
+atm shells out to `tmux` and honours `$TMUX` for targeting, so:
+
+```bash
+SOCK=$(tmux -L "$NAME" display -p '#{socket_path}')
+TMUX="$SOCK,0,0" uv run --frozen atm panes
+P=$(tmux -L "$NAME" display -p '#{pane_id}')
+TMUX="$SOCK,0,0" uv run --frozen atm sidebar --toggle --pane "$P"
+```
+
+Use `sleep` / `cat` as stand-ins for `claude` when testing process placement or cgroup scopes — never launch real AI
+sessions from an experiment.
+
+## Inspect
+
+```bash
+tmux -L "$NAME" list-panes -a -F '#{session_name}:#{window_index}.#{pane_index} #{pane_id} #{pane_current_command}'
+tmux -L "$NAME" display -p -t <pane> '#{pane_current_path}'
+```
+
+Remember tmux version differences: 3.4 prints control characters in `-F` output as octal literals (`\037`), 3.6 emits
+raw bytes. If parsing "silently finds nothing", check this first (`tmux -V`).
+
+## Stop — always, even on failure
+
+```bash
+tmux -L "$NAME" kill-server
+ls /tmp/tmux-$(id -u)/            # only `default` should remain
+```
+
+Never `pkill -f tmux`. Never `kill-server` without `-L`. Never `source-file ~/.tmux.conf` on the user's server from a
+script — it re-runs every side-effecting line.
+
+## Record
+
+A conclusion that came from an experiment goes into `research/experiments/<yyyy-mm-dd>-<tag>/` (script + captured
+output) and is cited from the code comment that relies on it. Numbers without a recorded experiment are estimates and
+must be labelled as such.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,74 @@
+# AGENTS.md — for any agent working in this repo (Claude Code / Codex / Pi / humans)
+
+One line: **atm is a tmux session manager for AI CLIs** — it merges Claude Code / Codex / Pi session history into one
+list and drops a session into a chosen pane, plus a persistent sidebar to swap between running panes. No GUI, no layout
+sync, no tmux private protocol. Positioning and trade-offs: `README.md`.
+
+## Layout
+
+```
+src/atm/            product code (src layout, zero runtime deps, Python >= 3.11)
+  sources/          one adapter per CLI: discover() -> Iterator[FileRef], parse(ref) -> SessionEntry | None
+  index.py          aggregation + cache; MUST NOT import tmux.py (keeps the door open for other backends)
+  dispatch.py       resume command construction + cgroup memory gate + dispatch into a pane
+  tmux.py           every tmux interaction; public CLI only
+  install.py / persist.py / guard.py   ~/.tmux.conf key block / resurrect+continuum block / aggregate slice
+  config.py         ~/.config/atm/config.toml; `atm config`, `atm claude|codex|pi` launch wrapper
+tests/              pytest; tmp_path fixtures ONLY — never read real session data
+docs/usage*.md      usage (en/cn/ja); docs/reference.md (Chinese) full options, measured numbers, JSONL formats
+research/           research log and experiments, not packaged; README*.md = why it's built this way / pitfalls
+```
+
+## Commands
+
+```bash
+uv run --frozen pytest                 # full suite (--frozen is mandatory: bare `uv run` rewrites index URLs in uv.lock)
+uv run --frozen ruff check .           # lint (research/ is excluded)
+uv run --frozen ruff format --check .
+uv run --frozen atm doctor             # data sources / tmux / persistence / memory gate in one pass
+uv build                               # wheel + sdist; sdist excludes research/ (only-include)
+```
+
+## Hard rules (violations get sent back)
+
+1. **Session data is read-only.** `~/.claude/projects/`, `~/.codex/`, `~/.pi/agent/sessions/` belong to the CLIs.
+   No code path may write, move, delete or "tidy" them. Tests use their own fixtures.
+2. **tmux through the public CLI only.** Never read or write `/tmp/tmux-<uid>/*` sockets; never parse anything but
+   the documented control-mode (`-CC`) text protocol.
+3. **tmux experiments on a real machine use `tmux -L <name> -f /dev/null` — both flags — and `kill-server` when done.**
+   `-L` alone still sources the user's `~/.tmux.conf`; with `@continuum-restore on` that restores their whole saved
+   layout into your test server, and the extra server silently disables their autosave. Never touch the default
+   server. Details: `.claude/skills/tmux-experiment/SKILL.md`.
+4. **Defensive parsing.** All three JSONL formats were reverse-engineered, not published contracts. Tolerate unknown
+   types / missing fields / dirty lines; one bad record must never take down the index.
+5. **The index layer does not depend on tmux.** `index.py` and everything below it (model / sources / cache / jsonl)
+   never import `tmux.py`.
+6. **Never upload session data.** atm is a local tool.
+7. **Performance claims need measurements.** Numbers come from `research/experiments/`; impressions are labelled as such.
+8. **Zero runtime dependencies.** stdlib first; a new dependency needs a reason (atm cold-starts inside `display-popup`).
+
+## Conventions
+
+- Branch from latest `main`; commit prefixes `feat:` / `fix:` / `docs:` / `test:` / `chore:`; PR body has three
+  sections: motivation / summary of changes / how it was verified.
+- **Docs come in three languages.** `README*.md`, `docs/usage*.md`, `research/README*.md` each exist as en / cn / ja —
+  change one, change all three. `docs/reference.md` is Chinese only.
+- **Version lives in three places:** `pyproject.toml`, `src/atm/__init__.py`, the root package in `uv.lock`.
+  Release procedure: `.claude/skills/release/SKILL.md`.
+- Session entries are the named type `SessionEntry`, never bare dicts. When discussing "remembering state", say which
+  layer: L1 visual / L2 process / L3 conversation (defined in `research/README.md`).
+- TDD: a failing test first for new features; a reproducing test first for bug fixes.
+- Adding a new CLI session source touches 9 places — follow `.claude/skills/add-session-source/SKILL.md`.
+- Anything that modifies the user's global environment (`~/.tmux.conf`, systemd units, `~/.config/atm`) must be:
+  marker-delimited / backed up before writing / idempotent / uninstallable / hands off the user's own content.
+
+## Known pitfalls (read before touching related code)
+
+`research/README.md` → "Known pitfalls". Highlights: tmux 3.4 escapes `\x1f` to the literal `\037`; the tmux server's
+PATH is a snapshot from when it started; tmux-resurrect saves the *child* process command line; an empty save file kills
+a freshly started server; continuum silently skips its autosave hook when another server exists. Every one was measured.
+
+## Out of scope
+
+A resident daemon / GUI (architecture forks A/B are undecided, not rejected); tmux wire protocol; uploading session
+data; letting resurrect relaunch claude/codex at boot (mass relaunch ate all memory — the 2026-08-12 incident).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,71 +1,10 @@
-# ai-terminal-manager
+@AGENTS.md
 
-本目录是 `research/` 工作区下的一个单次研究项目。工作区整体约定见 `../CLAUDE.md`，全局规则见 `~/.claude/CLAUDE.md` + `~/.claude/rules/common/`。
+# Claude Code specifics
 
-## 主题
+Everything shared with other agents (Codex / Pi / humans) is in `AGENTS.md` above. Only Claude-specific items here:
 
-面向 AI CLI（Claude Code / Codex）的终端管理器：多格终端 + 可收纳的左侧「最近 AI 会话」侧栏，
-能把一条历史对话恢复到指定的分窗口。核心价值不在布局，在**把 AI 会话历史当一等公民**。
-
-## 目标
-
-**路线 C 已拍板并落地**（2026-08-12）：不做 GUI、不做布局同步，只做「AI 会话当一等公民」这一层——
-跨 agent（Claude Code / Codex / Pi）统一历史 → 投到指定 tmux pane，加一个常驻侧栏在运行中的格子之间 `swap-pane` 换位。
-面向的人群是服务器 / SSH 上用 tmux、同时开多个 AI 会话、用不了 GUI 的开发者。
-
-> 架构分岔口 A（tmux 后端 + GUI）/ B（自写 daemon）**没有被否掉，只是没做**，决策变量（要不要跨端接管）仍未回答。
-> 动手前先读 `research/README-cn.md` 的「未拍板的分岔口」和「已知的坑」两节（`research/README.md` 英文 / `README-ja.md` 日文同步）——
-> 那里的结论是查证过的，别重新推导、也别推翻不看。改任何一份文档时，三个语言版本要一起改。
-
-## 本目录结构
-
-产品代码在**仓库根目录**（标准 src 布局，`uv tool install git+…` 不带 `#subdirectory` 就能装，也发 PyPI：`ai-terminal-manager`）；
-研究材料整体收在 `research/`，可以整块搬走。
-
-```
-ai-terminal-manager/
-├── CLAUDE.md            # 本文件 — Claude Code 的研究上下文
-├── README.md            # 英文主 README（短：为什么做 / 是什么 / 怎么装 / 文档索引）；README-cn.md / README-ja.md 同步
-├── pyproject.toml       # ★ 包 ai-terminal-manager，命令 atm；零运行时依赖；uv 管理
-├── src/atm/             # ★ 产品代码
-├── tests/               # ★ pytest（只用 tmp_path，绝不碰真实会话数据）
-├── atm.tmux             # tpm 兼容的插件入口（给不想 uv install 的人）
-├── docs/usage.md        # 用法：四个键、浮层 / 侧栏、命令行、怎么工作（-cn / -ja 同步）
-├── docs/reference.md    # 完整选项、实测性能、三个 JSONL 的格式细节、内存闸门
-├── .github/workflows/   # ci（ruff + pytest）、publish（打 v* tag 发 PyPI，trusted publishing）
-└── research/            # 研究过程，不进包
-    ├── README.md        # 研究记录：需求、三层状态、已确认结论、分岔口、已知的坑、环境事实、日志（-cn / -ja 同步）
-    ├── notes/           # 讨论纪要、阅读笔记、决策记录、事故复盘
-    ├── experiments/     # 验证性实验：吞吐压测、原型脚本、实测数据
-    └── writeup/         # 报告 / 设计文档草稿
-```
-
-## 产品代码 vs 研究材料
-
-**研究笔记与产品代码分开**：`research/` 是研究过程，根目录的 `src/` `tests/` 是真要长期维护的东西。
-
-- 技术栈已定：**Python 3.11+，零运行时依赖**，`uv` 管理，hatchling 构建。sdist / wheel 只打包 `src/`、`tests/`、`atm.tmux` 和几个顶层文档，`research/` 不进包。
-- 一次性的验证脚本、压测、探针**不要**写进 `src/`，放 `research/experiments/<yyyy-mm-dd-tag>/`，再在代码注释里引用。
-- 代码注释里引用研究材料用相对仓库根的路径（`research/notes/…`），别用 `../../`。
-
-## 环境约定
-
-- 依赖管理用 `uv`（不要 conda / 裸 pip / poetry），版本由 `requires-python` 固定。在本仓库跑命令用 `uv run --frozen`，别让 `uv run` 顺手重写 `uv.lock` 里的镜像地址。
-- 秘密走 `.env`（gitignored），模板放 `.env.example`。
-- 平台：Windows 10 + WSL2（Ubuntu，systemd=true）。**跨 Windows/WSL 边界的行为都要实测，不要凭直觉**（9p、inotify、localhost、路径）。
-
-## 领域约定（本研究特有）
-
-- **区分 L1/L2/L3**（定义见 `README.md`）。讨论「记住状态」时一律说清是哪一层 —— 混着说是这个项目最容易犯的错。
-- **tmux 的两个协议层不要混**：unix socket 的 wire format 是内部实现，**绝不碰**；只用控制模式 `-CC` 的文本协议。
-- **读会话数据是只读的**：`~/.claude/projects/` 和 `~/.codex/` 里的文件由 CLI 自己管理，**只读不写**，别原地改、别整理、别删。
-- **格式假设要防御**：那两个 jsonl 的字段是逆向观察出来的，不是公开契约，CLI 升级可能变。解析要能容忍未知 type / 缺字段，**不要因为一条脏行整个侧栏挂掉**。
-- **结构化返回**：会话条目用具名类型（`SessionEntry(id, title, source, cwd, gitBranch, updatedAt)`），不要传裸 dict。
-- **性能声明要有实测**：`%output` 膨胀率、同时挂 N 个会话的 CPU —— 这类数字必须来自 `research/experiments/` 里的压测，不能估。
-
-## Claude 协作须知
-
-- 进入本研究先读 `README-cn.md` → `research/README-cn.md` → `research/notes/idea-log.md` → `research/notes/2026-08-12-design-session.md`。
-- 不要修改 `../reference/` 里的任何文件。
-- 涉及外部服务调用前，按全局规则先跟用户确认。
-- 装 tmux 插件 / 改 `~/.tmux.conf` 这类**动用户全局环境**的操作，先说清楚要改什么再动手。
+- Reading order when entering this repo: `README.md` → `research/README.md` → `research/notes/idea-log.md` →
+  `research/notes/2026-08-12-design-session.md` (the notes are in Chinese).
+- On-demand procedures live in `.claude/skills/`: `add-session-source`, `tmux-experiment`, `release`.
+- Before touching the user's global environment (tmux plugins, `~/.tmux.conf`, systemd units), say what will change first.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,9 @@
 # 贡献指南
 
-欢迎给 atm 提 PR。这份指南只有两条是硬约束（见下「铁律」），其余都是让评审更快的建议。
+欢迎给 atm 提 PR。硬约束见下「铁律」，其余都是让评审更快的建议。
+
+> 用 AI agent（Claude Code / Codex / Pi）干活的话，仓库根目录的 `AGENTS.md` 就是给它们看的同一套规矩，
+> 按需流程在 `.claude/skills/`。本文是给人看的版本，两边内容一致，以 `AGENTS.md` 为准。
 
 ## 开发环境
 
@@ -8,25 +11,27 @@ Linux 或 WSL2 + tmux（3.0+，开发基准 3.6）+ Python 3.11+。依赖管理�
 
 ```bash
 git clone https://github.com/lyfuci/ai-terminal-manager
-cd ai-terminal-manager/app
-uv sync                      # 建虚拟环境并安装 dev 依赖
-uv run pytest                # 全量测试
-uv run ruff check src tests  # lint
-uv run ruff format src tests # 格式化
+cd ai-terminal-manager
+uv sync --frozen                       # 建虚拟环境并安装 dev 依赖
+uv run --frozen pytest                 # 全量测试
+uv run --frozen ruff check .           # lint（research/ 已排除）
+uv run --frozen ruff format .          # 格式化
 ```
+
+`--frozen` 必带：裸 `uv run` 会按本机 uv 配置重新解析并把 `uv.lock` 里的索引地址改掉。
 
 装成本机命令：`uv tool install --editable .`（或 `uv tool install git+https://github.com/lyfuci/ai-terminal-manager`）。
 
 ## 铁律（不遵守的 PR 会被要求改）
 
-1. **会话数据只读**。atm 解析 `~/.claude/projects/` 和 `~/.codex/` 下的文件，这两个目录由
+1. **会话数据只读**。atm 解析 `~/.claude/projects/`、`~/.codex/`、`~/.pi/agent/sessions/` 下的文件，这些目录由
    CLI 自己管理 —— 任何代码路径都不得写入、移动、删除或“整理”它们。测试只能用自建的
    tmp_path fixture，绝不读取贡献者机器上的真实会话数据。
 2. **tmux 只走公开 CLI**。绝不读写 `/tmp/tmux-<uid>/*` 的 unix socket，也绝不解析控制模式
    (`-CC`) 之外的上游私有协议。需要 tmux 的测试用临时 fixture，不用真 server。
 3. **索引层不依赖 tmux**。`src/atm/index.py` 及其下游（model / sources / cache / jsonl）刻意
    保持可以在 tmux 之外运行，为将来的其他后端留路。别在这里 import `tmux.py`。
-4. **格式假设要防御**。两个 CLI 的 JSONL 是逆向观察出来的，不是公开契约。解析必须容忍
+4. **格式假设要防御**。三家 CLI 的 JSONL 是逆向观察出来的，不是公开契约。解析必须容忍
    未知 type / 缺字段 / 脏行，绝不允许一条坏记录弄挂整个索引。
 
 ## 写测试
@@ -38,7 +43,7 @@ uv run ruff format src tests # 格式化
 
 ## tmux 实验规则（在真机器上验证时）
 
-- 一律用隔离 socket：`tmux -L <名字> -f /dev/null`。**只 `-L` 不 `-f` 不够** —— 新 server
+- 一律用隔离 socket：`tmux -L <名字> -f /dev/null`（完整仪式见 `.claude/skills/tmux-experiment/SKILL.md`）。**只 `-L` 不 `-f` 不够** —— 新 server
   仍会 source `~/.tmux.conf`，带 `@continuum-restore on` 的环境会把用户整个存档恢复到你的
   测试 server 里（实测发生过）。
 - 用完 `kill-server` 并删掉 socket 文件；不要用 `pkill -f tmux` 这类模式匹配清理。
@@ -55,7 +60,7 @@ uv run ruff format src tests # 格式化
 
 看看 issue 里的 `good first issue`；或者这些方向永远欢迎：
 
-- 新 CLI 的会话数据源适配（`src/atm/sources/` 加一个适配器）。
+- 新 CLI 的会话数据源适配（`src/atm/sources/` 加一个适配器，步骤见 `.claude/skills/add-session-source/SKILL.md`）。
 - 现有解析对 CLI 新版本的兼容修复（尤其标题提取，见 `text.py` 的注入包装剥离）。
 - TUI 体验、终端宽度/东亚字符处理（`text.py`）。
 


### PR DESCRIPTION
## 动机

想让 Claude Code / Codex / Pi 进仓库就知道规矩和流程。现状：规矩散在 CONTRIBUTING.md 和 CLAUDE.md 两处且不一致；
CLAUDE.md 还带着作者本机的路径（`../CLAUDE.md`、`~/.claude/rules/common/`、`../reference/`），clone 到别处全是死引用；
Codex 根本不读 CLAUDE.md。

## 改动摘要

- **`AGENTS.md`**（英文，唯一真相）：布局、命令、8 条铁律、约定、已知坑索引、不做的事。Codex / Pi 原生读；Claude 通过 `CLAUDE.md` 的 `@AGENTS.md` 引入；Gemini 需在 `.gemini/settings.json` 设 `contextFileName`（本仓库不用 Gemini，未加）
- **`CLAUDE.md`** 缩成引用 + 三条 Claude 特有项，去掉所有机器特有内容
- **`.claude/skills/`** 三个按需流程：`add-session-source`（9 个触点 + 资格审查）、`tmux-experiment`（隔离 socket 仪式）、`release`（三处版本 → tag → trusted publishing）
- **`CONTRIBUTING.md`**：修 `cd app` 等过期命令、加 `--frozen`、铁律补 pi、指向 AGENTS.md

## 验证方式

- 纯文档。新文件做过敏感信息扫描（主机名 / 家目录 / token / 邮箱 / IP）：无
- 三个 SKILL.md 的 frontmatter 可解析，description 均 < 300 字符
- skill 里引用的符号（`Source` / `SOURCE_TAG` / `RESUME_PROGRAMS` / `SourceRoots` / `_cached_source` / `AI_COMMANDS` / `LAUNCH_PROGRAMS` / 两条守卫测试）已逐一 grep 核对存在
- `$TMUX` 指向隔离 socket 驱动 atm 的做法在 #9 的自检里实测过

🤖 Generated with [Claude Code](https://claude.com/claude-code)
