### PR TITLE
feat: atm update 自我升级 + atm --version

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ uv run --frozen pytest                 # full suite (--frozen is mandatory: bare
 uv run --frozen ruff check .           # lint (research/ is excluded)
 uv run --frozen ruff format --check .
 uv run --frozen atm doctor             # data sources / tmux / persistence / memory gate in one pass
+atm update --check                     # how the installed atm was installed + whether PyPI has a newer release
 uv build                               # wheel + sdist; sdist excludes research/ (only-include)
 ```
 

--- a/README-cn.md
+++ b/README-cn.md
@@ -67,7 +67,7 @@ git clone https://github.com/lyfuci/ai-terminal-manager
 uv tool install ./ai-terminal-manager
 ```
 
-没有 uv 用 `pipx install ai-terminal-manager` 也一样。升级：`uv tool upgrade ai-terminal-manager`（git 装法则重跑加 `--reinstall`）。
+没有 uv 用 `pipx install ai-terminal-manager` 也一样。升级：**`atm update`**——它会识别 atm 是怎么装的（uv tool / pipx / pip，PyPI 还是 git）并跑对应的升级命令；`atm update --check` 只看不升。
 
 ### 体检、键位、持久化
 

--- a/README-ja.md
+++ b/README-ja.md
@@ -67,7 +67,7 @@ git clone https://github.com/lyfuci/ai-terminal-manager
 uv tool install ./ai-terminal-manager
 ```
 
-uv がなければ `pipx install ai-terminal-manager` でも同じ。更新は `uv tool upgrade ai-terminal-manager`（git 形式なら `--reinstall` を付けて再実行）。
+uv がなければ `pipx install ai-terminal-manager` でも同じ。更新は **`atm update`**——atm がどう入ったか（uv tool / pipx / pip、PyPI か git か）を判別して対応する更新コマンドを実行する；`atm update --check` は確認のみ。
 
 ### 健診・キーバインド・永続化
 

--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ git clone https://github.com/lyfuci/ai-terminal-manager
 uv tool install ./ai-terminal-manager
 ```
 
-Without uv, `pipx install ai-terminal-manager` works the same. To upgrade: `uv tool upgrade ai-terminal-manager`
-(or re-run the git form with `--reinstall`).
+Without uv, `pipx install ai-terminal-manager` works the same. To upgrade: **`atm update`** — it detects how atm was
+installed (uv tool / pipx / pip, PyPI or git) and runs the matching upgrade; `atm update --check` only looks.
 
 ### Check-up, key bindings, persistence
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -182,6 +182,19 @@ eval "$(atm pick --print)"
 ```
 
 
+## 升级
+
+```bash
+atm update            # 识别安装方式后跑对应命令：uv tool upgrade / pipx upgrade / pip install -U
+atm update --check    # 只比对版本，不动
+atm --version
+```
+
+识别依据是 `sys.executable` 的路径（`…/uv/tools/…`、`…/pipx/venvs/…`）和 PEP 610 的 `direct_url.json`
+（git 装的跟 main 最新 commit，PyPI 装的跟最新发行版；editable 装的只提示 `git pull`，不代劳）。
+**不要**对 uv tool 装的 atm 用 `pip install -U`：那会装进另一个解释器，PATH 上的 `atm` 还是旧的；
+而且 PyPI 上的 `atm` 是别人的包，本项目叫 `ai-terminal-manager`。
+
 ## 内存闸门（默认开）
 
 两层，都是 cgroup：

--- a/docs/usage-cn.md
+++ b/docs/usage-cn.md
@@ -35,6 +35,7 @@ atm swap %7 --into %3     # 把 %7 换进 %3
 atm park                  # 当前格子收进 bg
 atm prune -n              # 看看 bg 里有哪些空闲 shell 可以关（去掉 -n 才真关）
 atm index --rebuild       # 清缓存全量重建
+atm update                # 升级 atm 自己（识别 uv tool / pipx / pip）；--check 只看不升
 ```
 
 > 投递默认套一层 cgroup 内存闸门（`MemoryHigh=2G` / `MemoryMax=4G`）。

--- a/docs/usage-ja.md
+++ b/docs/usage-ja.md
@@ -35,6 +35,7 @@ atm swap %7 --into %3     # %7 を %3 に入れ替え
 atm park                  # 現在の pane を bg へ
 atm prune -n              # bg の中の閉じられる idle shell を表示（-n を外すと実際に閉じる）
 atm index --rebuild       # キャッシュを消して全再構築
+atm update                # atm 自身を更新（uv tool / pipx / pip を判別）；--check は確認のみ
 ```
 
 > 投入時はデフォルトで cgroup のメモリゲートを被せる（`MemoryHigh=2G` / `MemoryMax=4G`）。

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -38,6 +38,7 @@ atm swap %7 --into %3     # swap %7 into %3
 atm park                  # park the current pane in bg
 atm prune -n              # show idle shells in bg that could be closed (drop -n to actually close them)
 atm index --rebuild       # clear the cache and rebuild from scratch
+atm update                # upgrade atm itself (detects uv tool / pipx / pip); --check only looks
 ```
 
 > Dispatch wraps the process in a cgroup memory gate by default (`MemoryHigh=2G` / `MemoryMax=4G`). The reason:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 # PyPI 上 `atm` 已被占用；发行名用全名，命令名仍是 `atm`。
 name = "ai-terminal-manager"
-version = "0.2.0"
+version = "0.3.0"
 description = "Multi-session manager for AI CLIs (Claude Code / Codex / Pi) inside tmux: unified history, resume into any pane, persistent sidebar"
 readme = "README.md"
 license = "MIT"

--- a/src/atm/__init__.py
+++ b/src/atm/__init__.py
@@ -9,6 +9,6 @@
 
 from .model import IndexStats, SessionEntry, SessionIndex, Source
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 __all__ = ["IndexStats", "SessionEntry", "SessionIndex", "Source", "__version__"]

--- a/src/atm/cli.py
+++ b/src/atm/cli.py
@@ -96,6 +96,12 @@ def _guard_mod():
     return guard
 
 
+def _update_mod():
+    from . import update
+
+    return update
+
+
 def _sidebar_mod():
     from . import sidebar
 
@@ -109,6 +115,9 @@ def _build_parser() -> argparse.ArgumentParser:
             "AI Terminal Manager — Claude Code / Codex / Pi 的统一会话历史，投到指定 tmux pane"
         ),
     )
+    from . import __version__
+
+    parser.add_argument("--version", action="version", version=f"atm {__version__}")
     sub = parser.add_subparsers(dest="command", required=True)
 
     def add_filters(p: argparse.ArgumentParser) -> None:
@@ -248,6 +257,11 @@ def _build_parser() -> argparse.ArgumentParser:
         help="不写总量闸门的 systemd slice（默认写 ~/.config/systemd/user/atm-ai.slice）",
     )
     p_install.set_defaults(handler=_cmd_install)
+
+    p_update = sub.add_parser("update", help="升级 atm 自己（按安装方式选 uv tool / pipx / pip）")
+    p_update.add_argument("--check", action="store_true", help="只看有没有新版本，不升级")
+    p_update.add_argument("-y", "--yes", action="store_true", help="不问直接升")
+    p_update.set_defaults(handler=_cmd_update)
 
     p_config = sub.add_parser(
         "config",
@@ -665,6 +679,52 @@ def _apply_persist(plan) -> None:
         print("（刻意不自动 source —— 那会重跑你整份配置里带副作用的行）")
     print("手动存/恢复：prefix + Ctrl-s / prefix + Ctrl-r；")
     print("自动存档每 10 分钟，只在有客户端 attach 时触发")
+
+
+def _cmd_update(args: argparse.Namespace) -> int:
+    """升级 atm 自己。先说清楚「你是怎么装的、我准备跑什么」，再动手。"""
+    import subprocess
+
+    update = _update_mod()
+    info = update.detect()
+    current = update.current_version()
+    latest = update.latest_version()
+
+    print(f"当前 {current}（{info.describe()}）")
+    if latest is None:
+        print("PyPI 最新：查不到（离线或镜像滞后），不影响升级")
+    elif update.version_tuple(latest) > update.version_tuple(current):
+        print(f"PyPI 最新：{latest}  ← 有新版本")
+    else:
+        print(f"PyPI 最新：{latest}  已是最新")
+        if info.origin is update.Origin.GIT:
+            print("（git 装的会跟 main 最新 commit，可能比 PyPI 发行版还新）")
+
+    command = update.upgrade_command(info)
+    if command is None:
+        print()
+        print(update.manual_hint(info))
+        return EXIT_OK if info.origin is update.Origin.EDITABLE else EXIT_ERROR
+    if args.check:
+        print(f"\n升级命令：{' '.join(command)}")
+        return EXIT_OK
+
+    print(f"\n将执行：{' '.join(command)}")
+    if not args.yes and not _confirm("继续吗？"):
+        print("已取消。")
+        return EXIT_CANCELLED
+    try:
+        result = subprocess.run(command, check=False)
+    except FileNotFoundError:
+        print(f"atm: 找不到 {command[0]}，请手动升级", file=sys.stderr)
+        return EXIT_ERROR
+    if result.returncode != 0:
+        print(f"atm: 升级命令退出码 {result.returncode}", file=sys.stderr)
+        return EXIT_ERROR
+    # 新版本在新进程里才看得到；这里的 __version__ 还是老的
+    shown = subprocess.run(["atm", "--version"], capture_output=True, text=True, check=False)
+    print(f"完成：{shown.stdout.strip() or '（跑 atm --version 看版本）'}")
+    return EXIT_OK
 
 
 def _cmd_config(args: argparse.Namespace) -> int:

--- a/src/atm/update.py
+++ b/src/atm/update.py
@@ -1,0 +1,169 @@
+"""`atm update`：让 atm 自己升级自己。
+
+难点不在"跑一条升级命令"，在于**判断该跑哪一条**——同一个 `atm` 可能是 uv tool / pipx / pip 装的，
+装的来源又可能是 PyPI、git URL 或本地 editable。判断错了会出现两份 atm 打架
+（比如 `pip install -U` 装进了另一个解释器，PATH 上的 `atm` 还是旧的）。
+
+判断依据两处，都是标准的：
+1. `sys.executable` 的路径：uv tool 的 venv 在 `…/uv/tools/<name>/…`，
+   pipx 的在 `…/pipx/venvs/<name>/…`。
+2. PEP 610 的 `direct_url.json`（`importlib.metadata` 能读）：有 `vcs_info` 就是 git 装的，
+   `dir_info.editable` 就是 editable；都没有就是从索引（PyPI / 镜像）装的。
+
+版本比较只是提示，不是闸门：查不到 PyPI（离线 / 镜像滞后）照样可以升级。
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from enum import StrEnum
+from importlib import metadata
+
+DIST_NAME = "ai-terminal-manager"
+PYPI_JSON = f"https://pypi.org/pypi/{DIST_NAME}/json"
+GIT_URL = "https://github.com/lyfuci/ai-terminal-manager"
+
+
+class Installer(StrEnum):
+    UV_TOOL = "uv tool"
+    PIPX = "pipx"
+    PIP = "pip"
+    UNKNOWN = "unknown"
+
+
+class Origin(StrEnum):
+    INDEX = "index"  # PyPI 或镜像
+    GIT = "git"
+    EDITABLE = "editable"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True, slots=True)
+class InstallInfo:
+    installer: Installer
+    origin: Origin
+    detail: str = ""  # git 的 commit / editable 的目录，只用于展示
+
+    def describe(self) -> str:
+        parts = [self.installer.value, self.origin.value]
+        if self.detail:
+            parts.append(self.detail)
+        return " · ".join(parts)
+
+
+def current_version() -> str:
+    from . import __version__
+
+    return __version__
+
+
+_READ_ENV = object()
+
+
+def detect(
+    executable: str | None = None, direct_url: str | object | None = _READ_ENV
+) -> InstallInfo:
+    """两个参数都可注入，方便测试；默认看真实环境。
+
+    `direct_url=None` 表示「确实没有这个文件」，和「没传」是两回事。
+    """
+    exe = executable if executable is not None else sys.executable
+    if direct_url is _READ_ENV:
+        direct_url = _read_direct_url()
+    assert direct_url is None or isinstance(direct_url, str)
+
+    if "/uv/tools/" in exe or "\\uv\\tools\\" in exe:
+        installer = Installer.UV_TOOL
+    elif "/pipx/venvs/" in exe or "\\pipx\\venvs\\" in exe:
+        installer = Installer.PIPX
+    elif direct_url is not None or _dist_installed():
+        installer = Installer.PIP
+    else:
+        installer = Installer.UNKNOWN
+
+    origin, detail = Origin.INDEX, ""
+    if direct_url:
+        try:
+            data = json.loads(direct_url)
+        except json.JSONDecodeError:
+            data = {}
+        if isinstance(data.get("dir_info"), dict) and data["dir_info"].get("editable"):
+            origin, detail = Origin.EDITABLE, str(data.get("url", "")).removeprefix("file://")
+        elif isinstance(data.get("vcs_info"), dict):
+            origin = Origin.GIT
+            detail = str(data["vcs_info"].get("commit_id", ""))[:7]
+        elif data.get("url"):
+            origin, detail = Origin.GIT, ""
+    if installer is Installer.UNKNOWN:
+        origin = Origin.UNKNOWN
+    return InstallInfo(installer, origin, detail)
+
+
+def upgrade_command(info: InstallInfo) -> list[str] | None:
+    """None = 我们不该替用户升级（editable 或认不出来），调用方给人话。"""
+    if info.origin is Origin.EDITABLE:
+        return None
+    if info.installer is Installer.UV_TOOL:
+        # git 装的：uv 会重新解析同一个 ref，拿到最新 commit；PyPI 装的：拿最新发行版。
+        return ["uv", "tool", "upgrade", DIST_NAME]
+    if info.installer is Installer.PIPX:
+        return ["pipx", "upgrade", DIST_NAME]
+    if info.installer is Installer.PIP:
+        target = f"git+{GIT_URL}" if info.origin is Origin.GIT else DIST_NAME
+        return [sys.executable, "-m", "pip", "install", "--upgrade", target]
+    return None
+
+
+def manual_hint(info: InstallInfo) -> str:
+    if info.origin is Origin.EDITABLE:
+        where = info.detail or "源码目录"
+        return (
+            f"这是 editable 安装（{where}），升级就是 `git pull`；改了依赖再 `uv sync --frozen`。"
+        )
+    return (
+        "认不出这份 atm 是怎么装的。手动升级：\n"
+        f"  uv tool upgrade {DIST_NAME}        # uv tool 装的\n"
+        f"  pipx upgrade {DIST_NAME}           # pipx 装的\n"
+        f"  pip install -U {DIST_NAME}         # pip 装的（注意 PyPI 上的 `atm` 是别人的包）"
+    )
+
+
+def latest_version(timeout: float = 5.0) -> str | None:
+    """问 PyPI 最新版本。拿不到返回 None，绝不抛——它只是提示。"""
+    try:
+        req = urllib.request.Request(PYPI_JSON, headers={"User-Agent": f"atm/{current_version()}"})
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            data = json.load(resp)
+        version = data.get("info", {}).get("version")
+        return str(version) if version else None
+    except (urllib.error.URLError, TimeoutError, ValueError, OSError):
+        return None
+
+
+def version_tuple(v: str) -> tuple[int, ...]:
+    """够用的版本比较：只认 `1.2.3` 这种，别的段当 0。"""
+    out = []
+    for part in v.split("."):
+        m = re.match(r"\d+", part)  # 只取开头的数字：`0rc1` 是 0，不是 01
+        out.append(int(m.group()) if m else 0)
+    return tuple(out)
+
+
+def _read_direct_url() -> str | None:
+    try:
+        return metadata.distribution(DIST_NAME).read_text("direct_url.json")
+    except metadata.PackageNotFoundError:
+        return None
+
+
+def _dist_installed() -> bool:
+    try:
+        metadata.distribution(DIST_NAME)
+        return True
+    except metadata.PackageNotFoundError:
+        return False

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,0 +1,153 @@
+"""`atm update`：怎么装的就用什么升，认不出就不乱动。不真跑升级、不真访问网络。"""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+import pytest
+
+from atm import cli, update
+
+GIT = json.dumps({"url": update.GIT_URL, "vcs_info": {"vcs": "git", "commit_id": "2521c6b9b7f0"}})
+EDITABLE = json.dumps({"url": "file:///src/atm-repo", "dir_info": {"editable": True}})
+
+
+@pytest.mark.parametrize(
+    ("exe", "direct_url", "installer", "origin"),
+    [
+        ("/home/u/.local/share/uv/tools/ai-terminal-manager/bin/python3", GIT, "uv tool", "git"),
+        ("/home/u/.local/share/uv/tools/ai-terminal-manager/bin/python3", None, "uv tool", "index"),
+        ("/home/u/.local/pipx/venvs/ai-terminal-manager/bin/python", None, "pipx", "index"),
+        ("/usr/bin/python3", GIT, "pip", "git"),
+        ("/src/atm-repo/.venv/bin/python", EDITABLE, "pip", "editable"),
+    ],
+)
+def test_detect_installer_and_origin(exe, direct_url, installer, origin) -> None:
+    info = update.detect(executable=exe, direct_url=direct_url)
+    assert info.installer.value == installer
+    assert info.origin.value == origin
+
+
+def test_detect_git_detail_is_short_commit() -> None:
+    info = update.detect(executable="/x/uv/tools/a/bin/python", direct_url=GIT)
+    assert info.detail == "2521c6b"
+
+
+def test_detect_editable_detail_is_directory() -> None:
+    info = update.detect(executable="/src/atm-repo/.venv/bin/python", direct_url=EDITABLE)
+    assert info.detail == "/src/atm-repo"
+
+
+def test_detect_unknown_when_nothing_matches(monkeypatch) -> None:
+    monkeypatch.setattr(update, "_dist_installed", lambda: False)
+    info = update.detect(executable="/usr/bin/python3", direct_url=None)
+    assert info.installer is update.Installer.UNKNOWN
+    assert info.origin is update.Origin.UNKNOWN
+
+
+def test_upgrade_command_per_installer() -> None:
+    uv = update.detect(executable="/x/uv/tools/a/bin/python", direct_url=None)
+    assert update.upgrade_command(uv) == ["uv", "tool", "upgrade", update.DIST_NAME]
+
+    pipx = update.detect(executable="/x/pipx/venvs/a/bin/python", direct_url=None)
+    assert update.upgrade_command(pipx) == ["pipx", "upgrade", update.DIST_NAME]
+
+    pip_git = update.detect(executable="/usr/bin/python3", direct_url=GIT)
+    cmd = update.upgrade_command(pip_git)
+    assert cmd is not None and cmd[-1] == f"git+{update.GIT_URL}" and "--upgrade" in cmd
+
+
+def test_editable_and_unknown_get_no_command(monkeypatch) -> None:
+    editable = update.detect(executable="/x/.venv/bin/python", direct_url=EDITABLE)
+    assert update.upgrade_command(editable) is None
+    assert "git pull" in update.manual_hint(editable)
+
+    monkeypatch.setattr(update, "_dist_installed", lambda: False)
+    unknown = update.detect(executable="/usr/bin/python3", direct_url=None)
+    assert update.upgrade_command(unknown) is None
+    assert "uv tool upgrade" in update.manual_hint(unknown)
+
+
+def test_version_tuple_ordering() -> None:
+    assert update.version_tuple("0.2.0") < update.version_tuple("0.3.0")
+    assert update.version_tuple("0.10.0") > update.version_tuple("0.9.9")
+    assert update.version_tuple("1.0.0rc1") == (1, 0, 0)  # 够用就行
+
+
+def test_latest_version_swallows_network_errors(monkeypatch) -> None:
+    import urllib.request
+
+    def boom(*a, **k):
+        raise TimeoutError
+
+    monkeypatch.setattr(urllib.request, "urlopen", boom)
+    assert update.latest_version() is None
+
+
+def test_latest_version_parses_pypi_json(monkeypatch) -> None:
+    import io
+    import urllib.request
+
+    class Resp(io.BytesIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    monkeypatch.setattr(
+        urllib.request, "urlopen", lambda *a, **k: Resp(b'{"info": {"version": "9.9.9"}}')
+    )
+    assert update.latest_version() == "9.9.9"
+
+
+def test_cmd_update_check_does_not_run_anything(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        update, "detect", lambda: update.InstallInfo(update.Installer.UV_TOOL, update.Origin.INDEX)
+    )
+    monkeypatch.setattr(update, "latest_version", lambda: "9.9.9")
+    ran = []
+    import subprocess
+
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: ran.append(a))
+    assert cli._cmd_update(argparse.Namespace(check=True, yes=False)) == cli.EXIT_OK
+    out = capsys.readouterr().out
+    assert "有新版本" in out and "uv tool upgrade" in out
+    assert ran == []
+
+
+def test_cmd_update_runs_command_with_yes(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        update, "detect", lambda: update.InstallInfo(update.Installer.PIPX, update.Origin.INDEX)
+    )
+    monkeypatch.setattr(update, "latest_version", lambda: None)
+    import subprocess
+
+    calls = []
+
+    class R:
+        returncode = 0
+        stdout = "atm 9.9.9"
+
+    monkeypatch.setattr(subprocess, "run", lambda cmd, **k: (calls.append(cmd), R())[1])
+    assert cli._cmd_update(argparse.Namespace(check=False, yes=True)) == cli.EXIT_OK
+    assert calls[0] == ["pipx", "upgrade", update.DIST_NAME]
+    assert "完成：atm 9.9.9" in capsys.readouterr().out
+
+
+def test_cmd_update_editable_explains_and_exits_ok(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        update,
+        "detect",
+        lambda: update.InstallInfo(update.Installer.PIP, update.Origin.EDITABLE, "/src/repo"),
+    )
+    monkeypatch.setattr(update, "latest_version", lambda: None)
+    assert cli._cmd_update(argparse.Namespace(check=False, yes=True)) == cli.EXIT_OK
+    assert "git pull" in capsys.readouterr().out
+
+
+def test_version_flag() -> None:
+    with pytest.raises(SystemExit) as exc:
+        cli._build_parser().parse_args(["--version"])
+    assert exc.value.code == 0

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "ai-terminal-manager"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## 动机

想一条命令升级 atm。难点不是跑升级，是**判断该跑哪条**：uv tool / pipx / pip × PyPI / git / editable。
选错会出现两份 atm 打架——比如对 uv tool 装的用 `pip install -U`，装进了另一个解释器，PATH 上的 `atm` 还是旧的（而且 PyPI 上的 `atm` 是别人的包）。

## 改动摘要

- `update.py`：按 `sys.executable` 路径 + PEP 610 `direct_url.json` 识别安装方式与来源，映射到 `uv tool upgrade` / `pipx upgrade` / `pip install --upgrade [git+URL]`；editable 只提示 `git pull`；认不出就打印三种手动命令
- `atm update`（`--check` 只看，`-y` 免确认），升级后另起进程打 `atm --version`
- `atm --version`
- 文档：README ×3 / usage ×3 / reference「升级」节 / AGENTS.md 命令段；版本 0.3.0

## 验证方式

- 292 passed（新增 `tests/test_update.py` 14 条：五种安装组合的识别、命令映射、editable/unknown 不代劳、版本比较、网络失败吞掉、`--check` 不执行、`-y` 执行）；ruff 干净
- 本机实测两种真实环境：仓库内 `uv run` → `pip · editable · <repo>`，只提示 `git pull`；uv tool 环境解释器 → `uv tool · git · 2521c6b` → `uv tool upgrade ai-terminal-manager`
- 未实测 pipx 路径（本机没装 pipx），逻辑与 uv tool 对称

🤖 Generated with [Claude Code](https://claude.com/claude-code)
