### PR TITLE
fix: 加固九处（Codex 复审 + 本机复现）；publish 前先跑测试

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
+      - run: sudo apt-get update && sudo apt-get install -y tmux
+      # tag 直接发 PyPI，之前没有任何门：这里至少把测试和 lint 跑一遍再 build。
+      - run: uv sync --frozen
+      - run: uv run --frozen ruff check .
+      - run: uv run --frozen pytest
       - run: uv build
       - uses: actions/upload-artifact@v4
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@
 
 ## 开发环境
 
-Linux 或 WSL2 + tmux（3.0+，开发基准 3.6）+ Python 3.11+。依赖管理统一用 [uv](https://docs.astral.sh/uv/)。
+Linux 或 WSL2 + tmux（3.2+，开发基准 3.6）+ Python 3.11+。依赖管理统一用 [uv](https://docs.astral.sh/uv/)。
 
 ```bash
 git clone https://github.com/lyfuci/ai-terminal-manager

--- a/README-cn.md
+++ b/README-cn.md
@@ -47,7 +47,7 @@ atm 就补这一层，别的都不碰。
 
 ### 要求
 
-- Linux 或 WSL2 + **tmux ≥ 3.0**（开发基准 3.6，3.4 实测兼容）
+- Linux 或 WSL2 + **tmux ≥ 3.2**（`display-popup` 是 3.2 才有的；开发基准 3.6，3.4 实测兼容）
 - **Python ≥ 3.11**，零运行时依赖
 - 装了 Claude Code / Codex / Pi 至少一个（atm 只读它们写在 `~/.claude/projects/`、`~/.codex/sessions/`、`~/.pi/agent/sessions/` 的会话文件）
 

--- a/README-ja.md
+++ b/README-ja.md
@@ -47,7 +47,7 @@ atm はその層を補い、それ以外には触れない。
 
 ### 要件
 
-- Linux または WSL2 + **tmux ≥ 3.0**（開発基準 3.6、3.4 は実測で互換）
+- Linux または WSL2 + **tmux ≥ 3.2**（`display-popup` は 3.2 から；開発基準 3.6、3.4 は実測で互換）
 - **Python ≥ 3.11**、ランタイム依存ゼロ
 - Claude Code / Codex / Pi のうち少なくとも一つ（atm はそれらが `~/.claude/projects/`、`~/.codex/sessions/`、`~/.pi/agent/sessions/` に書くセッションファイルを読むだけ）
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ layouts (tmux is a binary split tree).
 
 ### Requirements
 
-- Linux or WSL2 with **tmux ≥ 3.0** (developed against 3.6, tested compatible with 3.4)
+- Linux or WSL2 with **tmux ≥ 3.2** (`display-popup` appeared in 3.2; developed against 3.6, tested on 3.4)
 - **Python ≥ 3.11**, zero runtime dependencies
 - at least one of Claude Code / Codex / Pi installed (atm only reads the session files they write to
   `~/.claude/projects/`, `~/.codex/sessions/`, `~/.pi/agent/sessions/`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 # PyPI 上 `atm` 已被占用；发行名用全名，命令名仍是 `atm`。
 name = "ai-terminal-manager"
-version = "0.3.0"
+version = "0.4.0"
 description = "Multi-session manager for AI CLIs (Claude Code / Codex / Pi) inside tmux: unified history, resume into any pane, persistent sidebar"
 readme = "README.md"
 license = "MIT"

--- a/src/atm/__init__.py
+++ b/src/atm/__init__.py
@@ -9,6 +9,6 @@
 
 from .model import IndexStats, SessionEntry, SessionIndex, Source
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 __all__ = ["IndexStats", "SessionEntry", "SessionIndex", "Source", "__version__"]

--- a/src/atm/cli.py
+++ b/src/atm/cli.py
@@ -52,13 +52,20 @@ def main(argv: Sequence[str] | None = None) -> int:
         args = parser.parse_args(raw)
     try:
         return args.handler(args)
-    except (DispatchError, ValueError) as exc:
-        # ValueError = 参数自身不合法（如 --key 1）。argparse 管不到这类跨参数约束，
-        # 但用户不该为此看到一屏 traceback。
-        print(f"atm: {exc}", file=sys.stderr)
-        return EXIT_ERROR
     except KeyboardInterrupt:
         return EXIT_CANCELLED
+    except BrokenPipeError:
+        # `atm list | head`：下游先关了管道，不是错。
+        # 把 stdout 换成 devnull，免得解释器退出时再报一次。
+        os.dup2(os.open(os.devnull, os.O_WRONLY), sys.stdout.fileno())
+        return EXIT_OK
+    except (DispatchError, ValueError, RuntimeError, OSError) as exc:
+        # 预期内的失败（参数不合法 / 配置读不了 / tmux 没起 / 文件写不进去）只给一行人话。
+        # RuntimeError 覆盖 ConfUnreadable / BackupFailed / TmuxError。要堆栈：ATM_DEBUG=1。
+        if os.environ.get("ATM_DEBUG"):
+            raise
+        print(f"atm: {exc}", file=sys.stderr)
+        return EXIT_ERROR
 
 
 # ---------------------------------------------------------------- parser
@@ -163,11 +170,14 @@ def _build_parser() -> argparse.ArgumentParser:
 
     p_resume = sub.add_parser("resume", help="按 id 直接投递（不进 TUI）")
     p_resume.add_argument("session_id", help="会话 id（可以只写前缀）")
-    p_resume.add_argument("--pane", help="投到这个 pane")
-    p_resume.add_argument("--split", action="store_true")
-    p_resume.add_argument("--window", action="store_true")
-    p_resume.add_argument("--vertical", action="store_true")
-    p_resume.add_argument("--print", action="store_true")
+    target = p_resume.add_mutually_exclusive_group()
+    target.add_argument("--pane", help="投到这个 pane")
+    target.add_argument("--split", action="store_true", help="从当前 pane 分一格出来投")
+    target.add_argument("--window", action="store_true", help="新开 window 投")
+    target.add_argument("--print", action="store_true", help="只打印命令，不投")
+    p_resume.add_argument(
+        "--vertical", action="store_true", help="配合 --split：上下分而不是左右分"
+    )
     p_resume.add_argument("--force", action="store_true")
     p_resume.add_argument("--no-cache", action="store_true")
     p_resume.add_argument(
@@ -307,13 +317,13 @@ def _build_parser() -> argparse.ArgumentParser:
 
 def _cmd_list(args: argparse.Namespace) -> int:
     entries = _load_entries(args)
-    if not entries:
-        print("没有找到会话。跑 `atm doctor` 看看数据源在不在。", file=sys.stderr)
-        return EXIT_OK
-
     limited = entries[: args.limit] if args.limit and args.limit > 0 else entries
     if args.json:
+        # 空也要是合法 JSON（`[]`），否则 `atm list --json | jq` 在没有会话的机器上直接炸。
         print(json.dumps([e.to_json() for e in limited], ensure_ascii=False, indent=2))
+        return EXIT_OK
+    if not entries:
+        print("没有找到会话。跑 `atm doctor` 看看数据源在不在。", file=sys.stderr)
         return EXIT_OK
 
     now = datetime.now(tz=UTC)
@@ -393,6 +403,7 @@ def _cmd_index(args: argparse.Namespace) -> int:
                     "parsed": stats.parsed,
                     "skipped": stats.skipped,
                     "elapsedMs": stats.elapsed_ms,
+                    "cacheWritten": stats.cache_written,
                     "cachePath": str(cache_mod.default_cache_path()),
                 },
                 ensure_ascii=False,
@@ -581,13 +592,14 @@ def _cmd_doctor(args: argparse.Namespace) -> int:
     _report_persist(_persist_mod().status())
 
     print("\n== 内存闸门 ==")
-    _report_guard()
+    guard_ok = _report_guard()
 
     print("\n== 索引 ==")
     result = index_mod.build()
     print(f"  {result.stats.describe()}")
     _print_source_breakdown(result)
-    return EXIT_OK
+    # 没装某家 CLI 不算故障；配置文件读不了才算 —— 那意味着用户以为的限制根本没生效。
+    return EXIT_OK if guard_ok else EXIT_ERROR
 
 
 def _cmd_install(args: argparse.Namespace) -> int:
@@ -612,6 +624,9 @@ def _cmd_install(args: argparse.Namespace) -> int:
     if persist_plan is not None:
         print()
         print(persist_plan.describe())
+    if not args.no_slice:
+        print()
+        print(_guard_mod().describe_plan(_config_mod().load().memory_slice))
 
     if args.print:
         return EXIT_OK
@@ -793,8 +808,10 @@ def _cmd_uninstall(args: argparse.Namespace) -> int:
 
     removed, backup = _install_mod().remove(conf_path)
     removed_persist, backup_persist = _persist_mod().remove(conf_path)
-    if not removed and not removed_persist:
-        print("没找到 atm 的配置块，无需移除。")
+    slice_name = _config_mod().load().memory_slice
+    removed_slice = _guard_mod().remove(slice_name)
+    if not (removed or removed_persist or removed_slice):
+        print("没找到 atm 写的任何东西（键位块 / 持久化块 / slice），无需移除。")
         return EXIT_OK
     if removed:
         print(f"已从 {conf_path} 移除键位块")
@@ -805,8 +822,7 @@ def _cmd_uninstall(args: argparse.Namespace) -> int:
         print(f"已从 {conf_path} 移除持久化块（~/.tmux/plugins 里已克隆的插件没动，不要了自己 rm）")
         if backup_persist:
             print(f"备份 {backup_persist}")
-    slice_name = _config_mod().load().memory_slice
-    if _guard_mod().remove(slice_name):
+    if removed_slice:
         print(f"已删总量闸门 {slice_name}（只删 atm 自己写的那份）")
     return EXIT_OK
 
@@ -826,23 +842,24 @@ def _confirm(prompt: str) -> bool:
 # ---------------------------------------------------------------- helpers
 
 
-def _report_guard() -> None:
+def _report_guard() -> bool:
+    """返回 False 表示配置本身有错（doctor 该非零退出）；机器不支持 cgroup 不算错。"""
     config = _config_mod()
     guard = _guard_mod()
     try:
         cfg = config.load()
     except config.ConfigError as exc:
         print(f"  ❌ {exc}")
-        return
+        return False
     if not dispatch_mod.memory_limits_available():
         print(
             "  cgroup: 不可用（无 systemd user manager 或 memory 控制器未 delegate）"
             "—— 一切限制被忽略"
         )
-        return
+        return True
     if not cfg.memory_enabled:
         print("  已关闭（memory.enabled=false）")
-        return
+        return True
     print(
         f"  单会话: MemoryHigh={cfg.memory_high} MemoryMax={cfg.memory_max}"
         "（atm claude / 投递时套）"
@@ -857,6 +874,7 @@ def _report_guard() -> None:
             "总量闸门形同虚设。跑 atm install 补上"
         )
     print("  直接敲 claude / codex 不受以上任何限制；要限就用 atm claude / atm codex")
+    return True
 
 
 def _report_persist(st) -> None:
@@ -1013,8 +1031,12 @@ def _memory_limit(args: argparse.Namespace) -> dispatch_mod.MemoryLimit | None:
     base = cfg.memory_limit()  # 已经考虑了 memory.enabled 和机器支持
     if base is None:
         return None
-    high = getattr(args, "mem_high", None) or base.high
-    max_ = getattr(args, "mem_max", None) or base.max
+    config = _config_mod()
+    high = getattr(args, "mem_high", None)
+    max_ = getattr(args, "mem_max", None)
+    # 命令行给的值走和 atm config 同一套校验：`--mem-high lots` 不该等到 systemd-run 才报错
+    high = config.validate_size("--mem-high", high) if high else base.high
+    max_ = config.validate_size("--mem-max", max_) if max_ else base.max
     return dispatch_mod.MemoryLimit(
         high=high, max=max_, swap_max=base.swap_max, slice_name=base.slice_name, user=base.user
     )

--- a/src/atm/config.py
+++ b/src/atm/config.py
@@ -98,20 +98,53 @@ def load(path: Path | None = None) -> Config:
         return Config()
     except (OSError, tomllib.TOMLDecodeError) as exc:
         raise ConfigError(f"{p} 读不了：{exc}") from exc
+    return _from_raw(raw, p)
+
+
+def _from_raw(raw: dict, p: Path) -> Config:
+    """把 TOML 字典变成 Config。结构错 / 键拼错都报错——静默忽略会让人以为设置生效了。"""
+    known_sections = {k.split(".", 1)[0] for k in KEYS}
+    for section in raw:
+        if section not in known_sections:
+            raise ConfigError(
+                f"{p}：不认识的段 [{section}]，只有 {', '.join(sorted(known_sections))}"
+            )
     cfg = Config()
-    for key, field in KEYS.items():
-        section, name = key.split(".", 1)
-        value = (raw.get(section) or {}).get(name.replace("-", "_"))
-        if value is not None:
-            cfg = replace(cfg, **{field: _coerce(key, value)})
+    for section in known_sections:
+        table = raw.get(section)
+        if table is None:
+            continue
+        if not isinstance(table, dict):
+            raise ConfigError(f"{p}：[{section}] 应该是一个表，收到 {type(table).__name__}")
+        valid = {
+            k.split(".", 1)[1].replace("-", "_"): k for k in KEYS if k.startswith(section + ".")
+        }
+        for name, value in table.items():
+            key = valid.get(name)
+            if key is None:
+                raise ConfigError(
+                    f"{p}：[{section}] 里不认识 {name!r}，可用：{', '.join(sorted(valid))}"
+                )
+            cfg = replace(cfg, **{KEYS[key]: _coerce(key, value)})
     return cfg
 
 
 def save(cfg: Config, path: Path | None = None) -> Path:
+    """原子写：先写临时文件再 rename，中途断电不会留下半个 TOML。"""
     p = path or config_path()
     p.parent.mkdir(parents=True, exist_ok=True)
-    p.write_text(dumps(cfg), encoding="utf-8")
+    tmp = p.with_name(p.name + ".tmp")
+    tmp.write_text(dumps(cfg), encoding="utf-8")
+    tmp.replace(p)
     return p
+
+
+def validate_size(label: str, value: str) -> str:
+    """给命令行参数用的同一套校验：`--mem-high lots` 在这里就报，不等 systemd-run。"""
+    s = str(value).strip()
+    if not _SIZE_RE.match(s):
+        raise ConfigError(f"{label} 要形如 4G / 512M / infinity，收到 {value!r}")
+    return s.upper() if s.lower() != "infinity" else "infinity"
 
 
 def set_value(cfg: Config, key: str, value: str) -> Config:
@@ -186,9 +219,7 @@ def _coerce(key: str, value: object):
         if not re.match(r"^[\w.-]+\.slice$", s):
             raise ConfigError(f"{key} 要形如 name.slice，收到 {value!r}")
         return s
-    if not _SIZE_RE.match(s):
-        raise ConfigError(f"{key} 要形如 4G / 512M / infinity，收到 {value!r}")
-    return s.upper() if s != "infinity" else s
+    return validate_size(key, s)
 
 
 # ---------------------------------------------------------------- 启动包装

--- a/src/atm/guard.py
+++ b/src/atm/guard.py
@@ -116,6 +116,23 @@ def install(
     return path, True
 
 
+def describe_plan(slice_name: str, directory: Path | None = None) -> str:
+    """`atm install --print` 用：会不会写、写多少。"""
+    st = status(slice_name, directory)
+    if st.exists:
+        who = "atm 写的" if st.ours else "你自己的"
+        return (
+            f"总量闸门 {st.path} 已存在（MemoryHigh={st.high} / MemoryMax={st.max}，{who}），不动。"
+        )
+    total = total_memory_bytes()
+    high, max_ = suggested_totals(total) if total else ("4G", "5G")
+    return (
+        f"将写入总量闸门 {st.path}：MemoryHigh={high} / MemoryMax={max_}"
+        f"（物理内存 {total >> 30 if total else '?'}G 的 50% / 65%），"
+        "然后 systemctl --user daemon-reload。"
+    )
+
+
 def remove(slice_name: str, directory: Path | None = None) -> bool:
     """只删我们自己写的（带 HEADER）。用户手写的一律不碰。"""
     st = status(slice_name, directory)

--- a/src/atm/install.py
+++ b/src/atm/install.py
@@ -319,12 +319,28 @@ def _strip_block(text: str, begin: str = MARKER_BEGIN, end: str = MARKER_END) ->
     return "\n".join(out) + ("\n" if out else "")
 
 
-def _backup(path: Path) -> Path | None:
-    """改全局配置前先留一份。备份失败不算致命，但要让调用方知道。"""
-    stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-    backup = path.with_name(f"{path.name}.bak-atm-{stamp}")
-    try:
-        shutil.copy2(path, backup)
+class BackupFailed(RuntimeError):
+    """备份写不出去。**不能**继续改原文件——没有退路的修改不做。"""
+
+
+def _backup(path: Path) -> Path:
+    """改全局配置前先留一份。
+
+    之前备份失败返回 None 然后照样往下写，等于「备份」是装饰。现在失败就抛，调用方整个中止。
+    文件名带微秒并在碰撞时加序号：同一秒内连跑两次 `atm install` 不会互相覆盖备份。
+    """
+    stamp = datetime.now().strftime("%Y%m%d-%H%M%S.%f")
+    for n in range(100):
+        suffix = f".bak-atm-{stamp}" + (f"-{n}" if n else "")
+        backup = path.with_name(path.name + suffix)
+        if backup.exists():
+            continue
+        try:
+            shutil.copy2(path, backup)
+        except OSError as exc:
+            raise BackupFailed(
+                f"备份 {path} 到 {backup} 失败（{exc.__class__.__name__}: {exc}）。"
+                f"为避免没有退路地改你的配置，这里直接中止。"
+            ) from exc
         return backup
-    except OSError:
-        return None
+    raise BackupFailed(f"{path} 的备份文件名连撞 100 次，放弃。")

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -1,0 +1,196 @@
+"""P0 加固：Codex 复审 + 本机复现出来的九处。每条先有失败测试再修。"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from atm import cli, config, dispatch, guard
+from atm import install as install_mod
+
+
+@pytest.fixture
+def cfg_path(tmp_path: Path, monkeypatch) -> Path:
+    p = tmp_path / "atm" / "config.toml"
+    monkeypatch.setenv("ATM_CONFIG", str(p))
+    return p
+
+
+# ---------------------------------------------------------------- list --json 空结果
+
+
+def test_list_json_empty_is_valid_json(monkeypatch, capsys) -> None:
+    """`atm list --json | jq` 在没有会话的机器上不能拿到空 stdout。"""
+    monkeypatch.setattr(cli, "_load_entries", lambda args: [])
+    ns = argparse.Namespace(json=True, limit=30)
+    assert cli._cmd_list(ns) == cli.EXIT_OK
+    out = capsys.readouterr().out
+    assert json.loads(out) == []
+
+
+# ---------------------------------------------------------------- 配置结构与未知键
+
+
+def test_config_section_must_be_table(cfg_path: Path) -> None:
+    cfg_path.parent.mkdir(parents=True)
+    cfg_path.write_text('memory = "x"\n', encoding="utf-8")
+    with pytest.raises(config.ConfigError, match="应该是一个表"):
+        config.load()
+
+
+def test_config_unknown_key_is_an_error_not_silence(cfg_path: Path) -> None:
+    cfg_path.parent.mkdir(parents=True)
+    cfg_path.write_text('[memory]\nhihg = "4G"\n', encoding="utf-8")
+    with pytest.raises(config.ConfigError, match="hihg"):
+        config.load()
+
+
+def test_config_unknown_section_is_an_error(cfg_path: Path) -> None:
+    cfg_path.parent.mkdir(parents=True)
+    cfg_path.write_text('[memroy]\nhigh = "4G"\n', encoding="utf-8")
+    with pytest.raises(config.ConfigError, match="memroy"):
+        config.load()
+
+
+def test_config_save_is_atomic_leaves_no_tmp(cfg_path: Path) -> None:
+    config.save(config.Config(memory_high="3G"))
+    assert cfg_path.exists()
+    assert not cfg_path.with_name(cfg_path.name + ".tmp").exists()
+    assert config.load().memory_high == "3G"
+
+
+# ---------------------------------------------------------------- 命令行值校验 / 互斥
+
+
+def test_mem_flag_values_are_validated(cfg_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(dispatch, "memory_limits_available", lambda: True)
+    ns = argparse.Namespace(no_mem_limit=False, mem_high="lots", mem_max=None)
+    with pytest.raises(config.ConfigError, match="--mem-high"):
+        cli._memory_limit(ns)
+    ns = argparse.Namespace(no_mem_limit=False, mem_high="3g", mem_max="6G")
+    limit = cli._memory_limit(ns)
+    assert limit is not None and limit.high == "3G"
+
+
+def test_resume_target_flags_are_mutually_exclusive() -> None:
+    parser = cli._build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["resume", "abc", "--split", "--window"])
+    with pytest.raises(SystemExit):
+        parser.parse_args(["resume", "abc", "--pane", "%1", "--print"])
+    ns = parser.parse_args(["resume", "abc", "--split", "--vertical"])
+    assert ns.split and ns.vertical
+
+
+# ---------------------------------------------------------------- main() 的错误面
+
+
+def test_main_turns_expected_errors_into_one_line(monkeypatch, capsys) -> None:
+    def boom(args):
+        raise install_mod.ConfUnreadable("配置读不了")
+
+    parser = cli._build_parser()
+    monkeypatch.setattr(cli, "_build_parser", lambda: parser)
+    ns = argparse.Namespace(handler=boom)
+    monkeypatch.setattr(parser, "parse_args", lambda raw: ns)
+    assert cli.main(["doctor"]) == cli.EXIT_ERROR
+    err = capsys.readouterr().err
+    assert err.strip() == "atm: 配置读不了"
+
+
+def test_main_reraises_with_debug_env(monkeypatch) -> None:
+    def boom(args):
+        raise install_mod.ConfUnreadable("x")
+
+    parser = cli._build_parser()
+    monkeypatch.setattr(cli, "_build_parser", lambda: parser)
+    monkeypatch.setattr(parser, "parse_args", lambda raw: argparse.Namespace(handler=boom))
+    monkeypatch.setenv("ATM_DEBUG", "1")
+    with pytest.raises(install_mod.ConfUnreadable):
+        cli.main(["doctor"])
+
+
+# ---------------------------------------------------------------- 备份必须成功
+
+
+def test_backup_failure_aborts_instead_of_overwriting(tmp_path: Path, monkeypatch) -> None:
+    conf = tmp_path / ".tmux.conf"
+    conf.write_text("set -g mouse on\n", encoding="utf-8")
+
+    def cant_copy(src, dst):
+        raise PermissionError("nope")
+
+    monkeypatch.setattr(install_mod.shutil, "copy2", cant_copy)
+    plan = install_mod.build_plan(conf_path=conf)
+    with pytest.raises(install_mod.BackupFailed):
+        install_mod.apply(plan, live=False)
+    assert conf.read_text(encoding="utf-8") == "set -g mouse on\n"  # 一个字没动
+
+
+def test_backup_names_do_not_collide(tmp_path: Path, monkeypatch) -> None:
+    conf = tmp_path / ".tmux.conf"
+    conf.write_text("a\n", encoding="utf-8")
+
+    class FrozenClock:
+        @staticmethod
+        def now():
+            from datetime import datetime
+
+            return datetime(2026, 9, 6, 1, 2, 3, 4)
+
+    monkeypatch.setattr(install_mod, "datetime", FrozenClock)
+    first = install_mod._backup(conf)
+    second = install_mod._backup(conf)
+    assert first != second and first.exists() and second.exists()
+
+
+# ---------------------------------------------------------------- doctor / install / uninstall
+
+
+def test_doctor_exits_nonzero_on_broken_config(cfg_path: Path, monkeypatch, capsys) -> None:
+    cfg_path.parent.mkdir(parents=True)
+    cfg_path.write_text("[memory\n", encoding="utf-8")
+    assert cli.main(["doctor"]) == cli.EXIT_ERROR
+    assert "❌" in capsys.readouterr().out
+
+
+def test_install_print_shows_slice_plan(
+    cfg_path: Path, tmp_path: Path, monkeypatch, capsys
+) -> None:
+    monkeypatch.setattr(guard, "unit_dir", lambda: tmp_path / "units")
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    assert cli.main(["install", "--print", "--no-persist"]) == cli.EXIT_OK
+    out = capsys.readouterr().out
+    assert "总量闸门" in out and "MemoryHigh=" in out
+    assert not (tmp_path / "units").exists()  # --print 什么都不写
+
+
+def test_uninstall_removes_slice_even_without_tmux_blocks(
+    cfg_path: Path, tmp_path: Path, monkeypatch, capsys
+) -> None:
+    units = tmp_path / "units"
+    monkeypatch.setattr(guard, "unit_dir", lambda: units)
+    monkeypatch.setattr(guard, "_daemon_reload", lambda: None)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    guard.install("atm-ai.slice", units, total_bytes=8 << 30)
+    assert (units / "atm-ai.slice").exists()
+
+    assert cli.main(["uninstall", "-y"]) == cli.EXIT_OK
+    assert not (units / "atm-ai.slice").exists()
+    assert "已删总量闸门" in capsys.readouterr().out
+
+
+def test_index_json_includes_cache_written(monkeypatch, capsys) -> None:
+    from atm import index as index_mod
+    from atm.model import IndexStats, SessionIndex
+
+    stats = IndexStats(
+        total=0, from_cache=0, parsed=0, skipped=0, elapsed_ms=1, cache_written=False
+    )
+    monkeypatch.setattr(index_mod, "build", lambda use_cache=True: SessionIndex((), stats))
+    assert cli._cmd_index(argparse.Namespace(rebuild=False, json=True)) == cli.EXIT_OK
+    data = json.loads(capsys.readouterr().out)
+    assert data["cacheWritten"] is False

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "ai-terminal-manager"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## 动机

让 Codex 对仓库做了一轮"通用能力缺什么"的复审，我逐条在真机复现，P0 全部属实。这是 P0 批次；P1（--verbose / --json / 补全 / 配置优先级 / NO_COLOR / pick 管道 / 路径可配置）在下一个 PR。

## 改动摘要

| 问题（均已复现） | 修法 |
|---|---|
| `atm list --json` 空结果 stdout 为空 | 输出 `[]` |
| `memory = "x"`（不是表）→ AttributeError 堆栈；拼错的键被静默忽略 | ConfigError 带人话；未知段/键报错 |
| `config.save()` 非原子 | tmp + replace |
| `--mem-high lots` 不校验 | 复用 `config.validate_size` |
| `resume --split --window` 同时接受 | 目标参数互斥组 |
| `ConfUnreadable` / `OSError` / `TmuxError` 冒堆栈 | `main()` 统一一行；`ATM_DEBUG=1` 才给堆栈；BrokenPipe 不算错 |
| `_backup()` 失败返回 None 照样写；秒级文件名碰撞 | 失败即中止（`BackupFailed`）；微秒 + 序号 |
| `doctor` 配置坏了仍 exit 0 | exit 1（没装某家 CLI 仍是 0） |
| `install --print` 不展示 slice 计划；`uninstall` 提前 return 漏删 slice | `guard.describe_plan`；三样各自清 |
| `index --json` 缺 `cacheWritten` | 补 |
| README 写 tmux ≥ 3.0、代码写 ≥ 3.2 | 统一 3.2（`display-popup` 是 3.2 才有） |
| tag 直接发 PyPI 没有任何门 | publish.yml 先 ruff + pytest |

版本 0.4.0。

## 验证方式

- 307 passed（新增 `tests/test_hardening.py` 15 条，每条对应一处）；ruff 干净
- 复现命令都在 PR 讨论前的会话里跑过：空 HOME 下 `list --json`、`memory = "x"`、坏 TOML 下 `doctor` 的退出码

🤖 Generated with [Claude Code](https://claude.com/claude-code)
