### PR TITLE
chore: bump version to 0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 # PyPI 上 `atm` 已被占用；发行名用全名，命令名仍是 `atm`。
 name = "ai-terminal-manager"
-version = "0.5.0"
+version = "0.6.0"
 description = "Multi-session manager for AI CLIs (Claude Code / Codex / Pi) inside tmux: unified history, resume into any pane, persistent sidebar"
 readme = "README.md"
 license = "MIT"

--- a/src/atm/__init__.py
+++ b/src/atm/__init__.py
@@ -9,6 +9,6 @@
 
 from .model import IndexStats, SessionEntry, SessionIndex, Source
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"
 
 __all__ = ["IndexStats", "SessionEntry", "SessionIndex", "Source", "__version__"]

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "ai-terminal-manager"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Motivation

Two feature PRs since v0.5.0 (#19 help overlay + #20 config-driven install / tmux options / keys / slice totals) add new subcommand behaviour and config keys → minor bump.

## Summary of changes

Version 0.5.0 → 0.6.0 in the three places: `pyproject.toml`, `src/atm/__init__.py`, the root package entry in `uv.lock` (hand-edited, no `uv lock`).

## How it was verified

- `ruff check` / `ruff format --check` clean; `pytest`: 401 passed.
- `uv build`: wheel contains only `atm/` + dist-info; sdist has no `research/`.
- README links all absolute (`grep -nE '\]\([^)h#]' README.md` empty).
- `uv run --frozen atm --version` → `atm 0.6.0`.

After merge: tag `v0.6.0` on main → publish workflow → PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
