### PR TITLE
fix: atm update retries straight from PyPI when the index mirror lags

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -196,6 +196,12 @@ atm --version
 **不要**对 uv tool 装的 atm 用 `pip install -U`：那会装进另一个解释器，PATH 上的 `atm` 还是旧的；
 而且 PyPI 上的 `atm` 是别人的包，本项目叫 `ai-terminal-manager`。
 
+**镜像滞后**：`atm update` 问的是 PyPI 本尊，但 `uv tool upgrade` 走的是你配的索引镜像（阿里云 / 清华等），
+镜像同步有几分钟到一小时延迟。实测发版后立刻 `atm update` 会出现「PyPI 已有 0.6.0、升级命令却 Nothing to upgrade」。
+于是升级命令跑完 atm 会再查一次版本：没升上去而 PyPI 确有新版，就提示并（确认后）改用
+`uv tool install --reinstall --default-index https://pypi.org/simple ai-terminal-manager` 直连 PyPI 再装一次。
+git 装的不经过索引，没有这个问题。
+
 ## 界面语言
 
 CLI 的输出、`--help`、TUI 提示、报错都有中 / 英 / 日三语。选择顺序：`ATM_LANG`（`zh` / `en` / `ja`）> `LC_ALL` > `LC_MESSAGES` > `LANG` > `locale.getlocale()`；`C` / `POSIX` 或认不出的语言 → 英文。

--- a/docs/usage-cn.md
+++ b/docs/usage-cn.md
@@ -35,7 +35,7 @@ atm swap %7 --into %3     # 把 %7 换进 %3
 atm park                  # 当前格子收进 bg
 atm prune -n              # 看看 bg 里有哪些空闲 shell 可以关（去掉 -n 才真关）
 atm index --rebuild       # 清缓存全量重建
-atm update                # 升级 atm 自己（识别 uv tool / pipx / pip）；--check 只看不升
+atm update                # 升级 atm 自己（识别 uv tool / pipx / pip）；--check 只看不升。镜像没同步到新版时会改直连 PyPI 再试
 ```
 
 > 投递默认套一层 cgroup 内存闸门（`MemoryHigh=2G` / `MemoryMax=4G`）。

--- a/docs/usage-ja.md
+++ b/docs/usage-ja.md
@@ -35,7 +35,7 @@ atm swap %7 --into %3     # %7 を %3 に入れ替え
 atm park                  # 現在の pane を bg へ
 atm prune -n              # bg の中の閉じられる idle shell を表示（-n を外すと実際に閉じる）
 atm index --rebuild       # キャッシュを消して全再構築
-atm update                # atm 自身を更新（uv tool / pipx / pip を判別）；--check は確認のみ
+atm update                # atm 自身を更新（uv tool / pipx / pip を判別）；--check は確認のみ。ミラーが遅れていれば PyPI 直結で再試行
 ```
 
 > 投入時はデフォルトで cgroup のメモリゲートを被せる（`MemoryHigh=2G` / `MemoryMax=4G`）。

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -38,7 +38,7 @@ atm swap %7 --into %3     # swap %7 into %3
 atm park                  # park the current pane in bg
 atm prune -n              # show idle shells in bg that could be closed (drop -n to actually close them)
 atm index --rebuild       # clear the cache and rebuild from scratch
-atm update                # upgrade atm itself (detects uv tool / pipx / pip); --check only looks
+atm update                # upgrade atm itself (detects uv tool / pipx / pip); --check only looks. If your index mirror lags PyPI it retries straight from PyPI
 ```
 
 > Dispatch wraps the process in a cgroup memory gate by default (`MemoryHigh=2G` / `MemoryMax=4G`). The reason:

--- a/src/atm/cli.py
+++ b/src/atm/cli.py
@@ -1041,9 +1041,43 @@ def _cmd_update(args: argparse.Namespace) -> int:
         )
         return EXIT_ERROR
     # 新版本在新进程里才看得到；这里的 __version__ 还是老的
-    shown = subprocess.run(["atm", "--version"], capture_output=True, text=True, check=False)
-    print(_("完成：{v0}").format(v0=shown.stdout.strip() or _("（跑 atm --version 看版本）")))
+    shown = _installed_version_line()
+    installed = update.installed_version_from(shown)
+    fallback = update.direct_index_command(info)
+    if (
+        latest
+        and installed
+        and update.version_tuple(installed) < update.version_tuple(latest)
+        and fallback is not None
+    ):
+        # 升级命令跑完版本没动、而 PyPI 明明有新版：镜像还没同步。直连 PyPI 再来一次。
+        print(
+            _("升级命令跑完还是 {installed}，但 PyPI 已有 {latest}：").format(
+                installed=installed, latest=latest
+            )
+        )
+        print(_("你的包管理器走的索引镜像还没同步到新版本。直连 PyPI 再试："))
+        print("  " + " ".join(fallback))
+        if not args.yes and not _confirm(_("继续吗？")):
+            print(_("已取消。镜像通常几分钟到一小时内追上，届时再 `atm update` 即可。"))
+            return EXIT_CANCELLED
+        result = subprocess.run(fallback, check=False)
+        if result.returncode != 0:
+            print(
+                _("atm: 直连 PyPI 的升级命令退出码 {code}").format(code=result.returncode),
+                file=sys.stderr,
+            )
+            return EXIT_ERROR
+        shown = _installed_version_line()
+    print(_("完成：{v0}").format(v0=shown or _("（跑 atm --version 看版本）")))
     return EXIT_OK
+
+
+def _installed_version_line() -> str:
+    import subprocess
+
+    shown = subprocess.run(["atm", "--version"], capture_output=True, text=True, check=False)
+    return (shown.stdout or "").strip()
 
 
 def _cmd_completion(args: argparse.Namespace) -> int:

--- a/src/atm/i18n_catalog.py
+++ b/src/atm/i18n_catalog.py
@@ -405,6 +405,10 @@ EN: dict[str, str] = {
     "键位块已重写 → {path}": "Key block rewritten → {path}",
     "键位块没更新：{exc}": "Key block not updated: {exc}",
     "键位还没装进 tmux；跑一次 `atm install` 才会绑 prefix + {k}": "Keys are not installed in tmux yet; run `atm install` once to bind prefix + {k}",
+    "atm: 直连 PyPI 的升级命令退出码 {code}": "atm: the direct-PyPI upgrade command exited with {code}",
+    "你的包管理器走的索引镜像还没同步到新版本。直连 PyPI 再试：": "The package index mirror your installer uses has not synced the new release yet. Retrying straight from PyPI:",
+    "升级命令跑完还是 {installed}，但 PyPI 已有 {latest}：": "The upgrade ran but the version is still {installed}, while PyPI already has {latest}:",
+    "已取消。镜像通常几分钟到一小时内追上，届时再 `atm update` 即可。": "Cancelled. Mirrors usually catch up within minutes to an hour; run `atm update` again then.",
 }
 
 JA: dict[str, str] = {
@@ -804,6 +808,10 @@ JA: dict[str, str] = {
     "键位块已重写 → {path}": "キーブロックを書き直しました → {path}",
     "键位块没更新：{exc}": "キーブロックを更新できませんでした：{exc}",
     "键位还没装进 tmux；跑一次 `atm install` 才会绑 prefix + {k}": "キーはまだ tmux に入っていません。`atm install` を一度実行すると prefix + {k} が割り当てられます",
+    "atm: 直连 PyPI 的升级命令退出码 {code}": "atm: PyPI 直結のアップグレードコマンドが終了コード {code}",
+    "你的包管理器走的索引镜像还没同步到新版本。直连 PyPI 再试：": "インストーラが使うインデックスミラーにまだ新版が同期されていません。PyPI に直結して再試行：",
+    "升级命令跑完还是 {installed}，但 PyPI 已有 {latest}：": "アップグレード後も {installed} のままですが、PyPI には既に {latest} があります：",
+    "已取消。镜像通常几分钟到一小时内追上，届时再 `atm update` 即可。": "取消しました。ミラーは通常数分〜1 時間で追いつきます。その後にもう一度 `atm update` を。",
 }
 
 CATALOG: dict[str, dict[str, str]] = {"en": EN, "ja": JA}

--- a/src/atm/update.py
+++ b/src/atm/update.py
@@ -28,6 +28,7 @@ from .i18n import _
 
 DIST_NAME = "ai-terminal-manager"
 PYPI_JSON = f"https://pypi.org/pypi/{DIST_NAME}/json"
+PYPI_SIMPLE = "https://pypi.org/simple"
 GIT_URL = "https://github.com/lyfuci/ai-terminal-manager"
 
 
@@ -119,6 +120,39 @@ def upgrade_command(info: InstallInfo) -> list[str] | None:
         target = f"git+{GIT_URL}" if info.origin is Origin.GIT else DIST_NAME
         return [sys.executable, "-m", "pip", "install", "--upgrade", target]
     return None
+
+
+def direct_index_command(info: InstallInfo) -> list[str] | None:
+    """镜像滞后时的兜底：绕过用户配置的索引，直连 PyPI 装最新版。
+
+    实测场景：国内镜像同步 PyPI 有几分钟到一小时的延迟。`atm update` 问 PyPI 本尊知道有 0.6.0，
+    但 `uv tool upgrade` 走镜像只看得到 0.4.0，于是"Nothing to upgrade"、版本原地不动。
+    只对从索引装的有意义；git 装的不经过索引。
+    """
+    if info.origin is not Origin.INDEX:
+        return None
+    if info.installer is Installer.UV_TOOL:
+        return ["uv", "tool", "install", "--reinstall", "--default-index", PYPI_SIMPLE, DIST_NAME]
+    if info.installer is Installer.PIPX:
+        return ["pipx", "install", "--force", "--index-url", PYPI_SIMPLE, DIST_NAME]
+    if info.installer is Installer.PIP:
+        return [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--upgrade",
+            "--index-url",
+            PYPI_SIMPLE,
+            DIST_NAME,
+        ]
+    return None
+
+
+def installed_version_from(output: str) -> str | None:
+    """`atm --version` 的输出（`atm 0.6.0`）→ `0.6.0`；认不出返回 None。"""
+    m = re.search(r"(\d+\.\d+\.\d+)", output)
+    return m.group(1) if m else None
 
 
 def manual_hint(info: InstallInfo) -> str:

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -147,6 +147,80 @@ def test_cmd_update_editable_explains_and_exits_ok(monkeypatch, capsys) -> None:
     assert "git pull" in capsys.readouterr().out
 
 
+def test_direct_index_command_only_for_index_installs() -> None:
+    uv = update.InstallInfo(update.Installer.UV_TOOL, update.Origin.INDEX)
+    cmd = update.direct_index_command(uv)
+    assert cmd[:4] == ["uv", "tool", "install", "--reinstall"]
+    assert cmd[4:] == ["--default-index", update.PYPI_SIMPLE, update.DIST_NAME]
+    pipx = update.InstallInfo(update.Installer.PIPX, update.Origin.INDEX)
+    assert "--index-url" in update.direct_index_command(pipx)
+    git = update.InstallInfo(update.Installer.UV_TOOL, update.Origin.GIT, "abc1234")
+    assert update.direct_index_command(git) is None
+    assert (
+        update.direct_index_command(
+            update.InstallInfo(update.Installer.UNKNOWN, update.Origin.UNKNOWN)
+        )
+        is None
+    )
+
+
+def test_installed_version_from_output() -> None:
+    assert update.installed_version_from("atm 0.6.0\n") == "0.6.0"
+    assert update.installed_version_from("") is None
+
+
+def test_cmd_update_falls_back_to_pypi_when_mirror_lags(monkeypatch, capsys) -> None:
+    """镜像只有 0.4.0：uv tool upgrade 说 Nothing to upgrade → 直连 PyPI 再装一次。"""
+    monkeypatch.setattr(
+        update, "detect", lambda: update.InstallInfo(update.Installer.UV_TOOL, update.Origin.INDEX)
+    )
+    monkeypatch.setattr(update, "latest_version", lambda: "0.6.0")
+    monkeypatch.setattr(update, "current_version", lambda: "0.4.0")
+    import subprocess
+
+    calls: list[list[str]] = []
+    state = {"version": "atm 0.4.0"}
+
+    class R:
+        def __init__(self, stdout: str = "") -> None:
+            self.returncode = 0
+            self.stdout = stdout
+
+    def fake_run(cmd, **k):
+        calls.append(cmd)
+        if cmd == ["atm", "--version"]:
+            return R(state["version"])
+        if "--default-index" in cmd:
+            state["version"] = "atm 0.6.0"  # 直连 PyPI 那次才真的升上去
+        return R()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    assert cli._cmd_update(argparse.Namespace(check=False, yes=True)) == cli.EXIT_OK
+    assert calls[0] == ["uv", "tool", "upgrade", update.DIST_NAME]
+    assert any("--default-index" in c for c in calls)
+    out = capsys.readouterr().out
+    assert "镜像" in out and "完成：atm 0.6.0" in out
+
+
+def test_cmd_update_no_fallback_when_upgrade_worked(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        update, "detect", lambda: update.InstallInfo(update.Installer.UV_TOOL, update.Origin.INDEX)
+    )
+    monkeypatch.setattr(update, "latest_version", lambda: "0.6.0")
+    import subprocess
+
+    calls: list[list[str]] = []
+
+    class R:
+        returncode = 0
+        stdout = "atm 0.6.0"
+
+    monkeypatch.setattr(subprocess, "run", lambda cmd, **k: (calls.append(cmd), R())[1])
+    assert cli._cmd_update(argparse.Namespace(check=False, yes=True)) == cli.EXIT_OK
+    assert not any("--default-index" in c for c in calls)
+    assert "镜像" not in capsys.readouterr().out
+
+
 def test_version_flag() -> None:
     with pytest.raises(SystemExit) as exc:
         cli._build_parser().parse_args(["--version"])


### PR DESCRIPTION
## Motivation

Observed right after v0.6.0 shipped: `atm update` printed `PyPI latest: 0.6.0 ← newer version available`, ran `uv tool upgrade ai-terminal-manager`, got `Nothing to upgrade` and finished with `Done: atm 0.4.0`. The version check talks to pypi.org; the upgrade goes through the user's configured mirror, which had not synced yet. atm knew better and still declared success.

## Summary of changes

- `update.direct_index_command(info)`: the bypass command per installer for index installs only (`uv tool install --reinstall --default-index https://pypi.org/simple …`, pipx `--index-url`, pip `--index-url`); `None` for git / editable / unknown.
- `update.installed_version_from(output)`: parses `atm --version`.
- `_cmd_update`: after the normal upgrade, re-reads the installed version. If it is still below the PyPI version and a bypass command exists, it explains the mirror lag, shows the command, confirms (or `-y`), runs it, and re-reads the version. Non-zero exit is reported as before.
- 4 EN/JA catalog rows; docs: `docs/reference.md` 升级 section, `docs/usage*.md` update line.

## How it was verified

- `uv run --frozen pytest`: 405 passed. New: bypass command per installer / none for git, version parsing, mirror-lag scenario (first upgrade leaves 0.4.0, fallback with `--default-index` yields 0.6.0, "镜像" explained), and the negative case (upgrade succeeded → no fallback, no mention).
- `ruff check` / `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
