### PR TITLE
feat(config): right-hand panel explains the selected key in the UI language

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -205,6 +205,7 @@ git 装的不经过索引，没有这个问题。
 ## 界面语言
 
 CLI 的输出、`--help`、TUI 提示、报错都有中 / 英 / 日三语。选择顺序：`ATM_LANG`（`zh` / `en` / `ja`）> `LC_ALL` > `LC_MESSAGES` > `LANG` > `locale.getlocale()`；`C` / `POSIX` 或认不出的语言 → 英文。
+`atm config` 编辑器右侧面板最后一行会告诉你当前界面语言和它来自哪个变量（`ATM_LANG` / `LC_ALL` / `LC_MESSAGES` / `LANG` / `locale` / `default`）。
 `--json` 的字段名与语言无关；`-v` 日志不翻译。源码里的消息是中文原文，翻译表在 `src/atm/i18n_catalog.py`，测试保证每条消息都有两种翻译且占位符一致——漏翻的会原样显示中文，不会崩。
 
 ## 日志与诊断
@@ -253,7 +254,7 @@ claude                       # 不带 atm 前缀 = 原生，不套任何限制
 ### 配置
 
 ```bash
-atm config                        # 终端里：交互式编辑器（↑↓ 选、Enter 改/切换、r 恢复默认、s 保存、? 帮助）；管道里 / --show：打印当前值和来源
+atm config                        # 终端里：交互式编辑器（↑↓ 选、Enter 改/切换、r 恢复默认、s 保存、? 帮助；≥90 列时右侧面板说明选中项：格式 / 默认 / 环境变量 / 来源 / 界面语言，窄了退回底部一行）；管道里 / --show：打印当前值和来源
 atm config memory.high 4G         # 软上限：超了节流 + 回收，不杀
 atm config memory.max 8G          # 硬上限：回收压不住才杀 —— 杀的是整个 scope，会话和它的子命令一起没
 atm config memory.enabled false   # 全关（atm claude 就等于 claude）

--- a/docs/usage-cn.md
+++ b/docs/usage-cn.md
@@ -71,7 +71,7 @@ ATM_LANG=en atm --help         # 界面语言：跟系统 LC_ALL / LC_MESSAGES /
 ## 内存闸门：`atm claude` 和 `claude` 的区别
 
 ```bash
-atm config                     # 交互式编辑器：↑↓ 选键，Enter 改/切换，s 保存，? 帮助（atm config --show 只打印）
+atm config                     # 交互式编辑器：↑↓ 选键，Enter 改/切换，s 保存，? 帮助；右侧面板按界面语言说明选中项（格式 / 默认 / 环境变量 / 来源）（atm config --show 只打印）
 atm config memory.high 4G      # 软上限：节流 + 回收，不杀
 atm config keys.pick s         # 选择器键（大写 = 只看当前目录）；还有 keys.sidebar、keys.popup-width/-height。保存即对运行中的 server 重绑
 atm config tmux.mouse true     # tmux 常用选项：mouse / focus-events / history-limit / base-index / renumber-windows → 写进 ~/.tmux.conf **最前面**的独立块（你后面的行能盖掉它），立即生效

--- a/docs/usage-ja.md
+++ b/docs/usage-ja.md
@@ -71,7 +71,7 @@ ATM_LANG=ja atm --help         # 表示言語：LC_ALL / LC_MESSAGES / LANG に�
 ## メモリゲート：`atm claude` と `claude` の違い
 
 ```bash
-atm config                     # 対話エディタ：↑↓ でキー選択、Enter で編集/切替、s で保存、? でヘルプ（atm config --show は表示のみ）
+atm config                     # 対話エディタ：↑↓ でキー選択、Enter で編集/切替、s で保存、? でヘルプ；右パネルが選択中の項目を表示言語で説明（形式 / デフォルト / 環境変数 / 由来）（atm config --show は表示のみ）
 atm config memory.high 4G      # ソフト上限：スロットリング + 回収、殺さない
 atm config keys.pick s         # ピッカーキー（大文字 = 現在のディレクトリのみ）；keys.sidebar、keys.popup-width/-height も。保存で実行中の server に再割り当て
 atm config tmux.mouse true     # tmux 共通オプション：mouse / focus-events / history-limit / base-index / renumber-windows → ~/.tmux.conf の**先頭**に独立ブロック（下のあなたの行が勝つ）、即時適用

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -75,7 +75,7 @@ the config first.
 ## Memory gate: `atm claude` vs `claude`
 
 ```bash
-atm config                     # interactive editor: ↑↓ pick a key, Enter edit/toggle, s save, ? help (atm config --show for plain text)
+atm config                     # interactive editor: ↑↓ pick a key, Enter edit/toggle, s save, ? help; a right-hand panel explains the selected key (format, default, env var, source) in the UI language (atm config --show for plain text)
 atm config memory.high 4G      # soft cap: throttle + reclaim, never kills
 atm config keys.pick s         # picker key (uppercase = current dir only); keys.sidebar, keys.popup-width/-height too. Saving rebinds the running server
 atm config tmux.mouse true     # common tmux options: mouse / focus-events / history-limit / base-index / renumber-windows → own block at the TOP of ~/.tmux.conf (your lines below win), applied live

--- a/src/atm/config_tui.py
+++ b/src/atm/config_tui.py
@@ -15,12 +15,17 @@ from __future__ import annotations
 
 import curses
 from collections.abc import Sequence
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, fields, replace
 from enum import StrEnum
 
-from . import config
+from . import config, i18n
 from .i18n import _
+from .text import display_width, truncate_display, wrap_display
 from .tui import _color, _Screen
+
+# 终端够宽才在右边放说明面板；窄了退回底部一行。列表本身要 ~50 列（键名 + 值 + 来源）。
+_PANEL_MIN_WIDTH = 90
+_LIST_MIN_WIDTH = 52
 
 _KEY_ESC = 27
 _KEY_ENTER = (curses.KEY_ENTER, 10, 13)
@@ -241,6 +246,58 @@ class ConfigEditor(_Screen):
         self._status = _("有未保存的改动：s 保存并退出，再按一次 q 放弃")
         return Action.NONE
 
+    # ------------------------------------------------------------ 说明面板（纯逻辑，可测）
+
+    @staticmethod
+    def panel_x(width: int) -> int | None:
+        """面板从第几列开始；None = 太窄，不画面板。"""
+        if width < _PANEL_MIN_WIDTH:
+            return None
+        return max(_LIST_MIN_WIDTH, width * 11 // 20)
+
+    @staticmethod
+    def format_hint(key: str) -> str:
+        """这个键接受什么样的值。和 config._coerce 的规则一一对应。"""
+        field = config.KEYS[key]
+        kind = next(f.type for f in fields(config.Config) if f.name == field)
+        if kind == "bool":
+            return _("true / false")
+        if kind == "int":
+            return _("0 或 1") if key == "tmux.base-index" else _("非负整数")
+        if key == "memory.slice":
+            return _("形如 name.slice")
+        if key in ("memory.slice-high", "memory.slice-max"):
+            return _("auto，或 24G / 512M 这样的大小")
+        if key in ("keys.pick", "keys.sidebar"):
+            return _("单个小写字母")
+        if key in ("keys.popup-width", "keys.popup-height"):
+            return _("80% 或 120")
+        return _("4G / 512M / infinity 这样的大小")
+
+    def panel_lines(self, row: Row, width: int) -> list[str]:
+        """面板正文，已按 width 折行。第一行是键名（调用方加粗）。"""
+        default = getattr(config.Config(), row.field)
+        default_shown = str(default).lower() if isinstance(default, bool) else str(default)
+        src = self._sources.get(row.key, "default")
+        lines: list[str] = [row.key, ""]
+        lines += wrap_display(_(config._HELP[row.key]), width)
+        lines.append("")
+        lines += wrap_display(_("格式：{v}").format(v=self.format_hint(row.key)), width)
+        lines.append(_("默认：{v}").format(v=default_shown))
+        lines.append(_("环境变量：{v}").format(v=config.env_var_for(row.key)))
+        lines.append(_("来源：{v}").format(v=src))
+        if self.env_override(row):
+            lines.append("")
+            lines += wrap_display(_("⚠ 环境变量覆盖中，改文件不生效；先 unset 它"), width)
+        lines.append("")
+        lines += wrap_display(
+            _("界面语言：{lang}（来自 {source}；ATM_LANG=zh|en|ja 可强制）").format(
+                lang=i18n.lang(), source=i18n.lang_source()
+            ),
+            width,
+        )
+        return lines
+
     # ------------------------------------------------------------ 画屏
 
     def run(self, stdscr: curses.window) -> Action:
@@ -259,7 +316,9 @@ class ConfigEditor(_Screen):
 
     def _draw(self, stdscr: curses.window) -> None:
         stdscr.erase()
-        height, _width = stdscr.getmaxyx()
+        height, width = stdscr.getmaxyx()
+        panel_x = self.panel_x(width)
+        list_limit = (panel_x - 1) if panel_x is not None else width - 1
         path = config.config_path()
         title = _("atm 配置  {path}{note}").format(
             path=path, note="" if path.exists() else _("（尚不存在，保存时创建）")
@@ -290,25 +349,33 @@ class ConfigEditor(_Screen):
             marker = "▸ " if selected else "  "
             x = self._put(stdscr, y, 0, marker + row.key.ljust(key_w), attr | _color(3))
             if selected and self._editing:
-                x = self._put(stdscr, y, x, self._buffer + "▏", attr | _color(2))
+                text = self._buffer + "▏"
+                x = self._put(
+                    stdscr, y, x, truncate_display(text, list_limit - x), attr | _color(2)
+                )
             else:
-                x = self._put(stdscr, y, x, self.value_of(row).ljust(val_w), attr)
+                text = self.value_of(row).ljust(val_w)
+                x = self._put(stdscr, y, x, truncate_display(text, list_limit - x), attr)
             src = self._sources.get(row.key, "default")
             if src != "default":
-                self._put(stdscr, y, x + 1, f"← {src}", attr | _color(4))
-            env = self.env_override(row)
-            if env:
+                tag = truncate_display(f"← {src}", max(0, list_limit - x - 1))
+                x = self._put(stdscr, y, x + 1, tag, attr | _color(4))
+            if self.env_override(row) and panel_x is None:
+                note = _("（环境变量覆盖中，改文件不生效）")
                 self._put(
                     stdscr,
                     y,
-                    x + 1 + len(src) + 3,
-                    _("（环境变量覆盖中，改文件不生效）"),
+                    x + 1,
+                    truncate_display(note, max(0, list_limit - x - 1)),
                     attr | _color(6),
                 )
 
         row = self._rows[self._cursor]
-        help_y = height - 3
-        self._put(stdscr, help_y, 0, _(config._HELP[row.key]), _color(5))
+        if panel_x is not None:
+            self._draw_panel(stdscr, row, panel_x, 3, height - 5, width)
+        else:
+            # 窄终端：说明退回底部一行
+            self._put(stdscr, height - 3, 0, _(config._HELP[row.key]), _color(5))
         if self._error:
             self._put(stdscr, height - 2, 0, "❌ " + self._error, _color(6))
         elif self._status:
@@ -323,6 +390,29 @@ class ConfigEditor(_Screen):
         self._put(stdscr, height - 1, 0, footer, _color(5))
         self._draw_help(stdscr)
         stdscr.refresh()
+
+    def _draw_panel(
+        self, stdscr: curses.window, row: Row, x0: int, y0: int, y1: int, width: int
+    ) -> None:
+        """右侧带边框的说明面板：占 x0 .. width-2，y0 .. y1。放不下的行直接不画。"""
+        box_w = width - 1 - x0
+        inner = box_w - 2
+        if inner < 8 or y1 - y0 < 2:
+            return
+        lines = self.panel_lines(row, inner - 2)
+        self._put(stdscr, y0, x0, "┌" + "─" * inner + "┐", _color(1))
+        body = y1 - y0 - 1
+        for i in range(body):
+            y = y0 + 1 + i
+            text = lines[i] if i < len(lines) else ""
+            self._put(stdscr, y, x0, "│", _color(1))
+            attr = curses.A_BOLD | _color(3) if i == 0 else 0
+            if text.startswith("⚠"):
+                attr = _color(6)
+            pad = " " * max(0, inner - 1 - display_width(text))
+            self._put(stdscr, y, x0 + 1, " " + text + pad, attr)
+            self._put(stdscr, y, x0 + box_w - 1, "│", _color(1))
+        self._put(stdscr, y1, x0, "└" + "─" * inner + "┘", _color(1))
 
 
 def run_config_editor() -> int:

--- a/src/atm/i18n.py
+++ b/src/atm/i18n.py
@@ -34,17 +34,29 @@ def reset_lang() -> None:
 
 
 def _detect() -> str:
+    return _detect_with_source()[0]
+
+
+def lang_source() -> str:
+    """当前语言是谁决定的：`ATM_LANG` / `LC_ALL` / `LC_MESSAGES` / `LANG` / `locale` / `default`。
+
+    给 `atm config` 的说明面板用 —— 用户看到界面是英文时，一眼知道该改哪个变量。
+    """
+    return _detect_with_source()[1]
+
+
+def _detect_with_source() -> tuple[str, str]:
     forced = os.environ.get("ATM_LANG", "").strip().lower()
     if forced:
-        return forced if forced in SUPPORTED else "en"
+        return (forced if forced in SUPPORTED else "en"), "ATM_LANG"
     for var in ("LC_ALL", "LC_MESSAGES", "LANG"):
         value = os.environ.get(var, "").strip()
         if not value:
             continue
         if value in ("C", "POSIX") or value.startswith(("C.", "POSIX.")):
-            return "en"
+            return "en", var
         code = value[:2].lower()
-        return code if code in SUPPORTED else "en"
+        return (code if code in SUPPORTED else "en"), var
     # 环境变量全空（某些 Windows 终端 / 服务里起的进程）：问一下 Python 的 locale 兜底
     try:
         import locale
@@ -52,7 +64,9 @@ def _detect() -> str:
         sys_locale = (locale.getlocale()[0] or "")[:2].lower()
     except (ValueError, TypeError):
         sys_locale = ""
-    return sys_locale if sys_locale in SUPPORTED else "en"
+    if sys_locale in SUPPORTED:
+        return sys_locale, "locale"
+    return "en", "default"
 
 
 def tr(message: str) -> str:

--- a/src/atm/i18n_catalog.py
+++ b/src/atm/i18n_catalog.py
@@ -409,6 +409,20 @@ EN: dict[str, str] = {
     "你的包管理器走的索引镜像还没同步到新版本。直连 PyPI 再试：": "The package index mirror your installer uses has not synced the new release yet. Retrying straight from PyPI:",
     "升级命令跑完还是 {installed}，但 PyPI 已有 {latest}：": "The upgrade ran but the version is still {installed}, while PyPI already has {latest}:",
     "已取消。镜像通常几分钟到一小时内追上，届时再 `atm update` 即可。": "Cancelled. Mirrors usually catch up within minutes to an hour; run `atm update` again then.",
+    "0 或 1": "0 or 1",
+    "4G / 512M / infinity 这样的大小": "a size like 4G / 512M / infinity",
+    "80% 或 120": "80% or 120",
+    "auto，或 24G / 512M 这样的大小": "auto, or a size like 24G / 512M",
+    "true / false": "true / false",
+    "⚠ 环境变量覆盖中，改文件不生效；先 unset 它": "⚠ Overridden by an environment variable; editing the file has no effect until you unset it",
+    "单个小写字母": "one lowercase letter",
+    "形如 name.slice": "like name.slice",
+    "来源：{v}": "Source: {v}",
+    "格式：{v}": "Format: {v}",
+    "环境变量：{v}": "Env var: {v}",
+    "界面语言：{lang}（来自 {source}；ATM_LANG=zh|en|ja 可强制）": "UI language: {lang} (from {source}; force with ATM_LANG=zh|en|ja)",
+    "非负整数": "a non-negative integer",
+    "默认：{v}": "Default: {v}",
 }
 
 JA: dict[str, str] = {
@@ -812,6 +826,20 @@ JA: dict[str, str] = {
     "你的包管理器走的索引镜像还没同步到新版本。直连 PyPI 再试：": "インストーラが使うインデックスミラーにまだ新版が同期されていません。PyPI に直結して再試行：",
     "升级命令跑完还是 {installed}，但 PyPI 已有 {latest}：": "アップグレード後も {installed} のままですが、PyPI には既に {latest} があります：",
     "已取消。镜像通常几分钟到一小时内追上，届时再 `atm update` 即可。": "取消しました。ミラーは通常数分〜1 時間で追いつきます。その後にもう一度 `atm update` を。",
+    "0 或 1": "0 か 1",
+    "4G / 512M / infinity 这样的大小": "4G / 512M / infinity のようなサイズ",
+    "80% 或 120": "80% か 120",
+    "auto，或 24G / 512M 这样的大小": "auto、または 24G / 512M のようなサイズ",
+    "true / false": "true / false",
+    "⚠ 环境变量覆盖中，改文件不生效；先 unset 它": "⚠ 環境変数で上書き中。unset するまでファイルの変更は効きません",
+    "单个小写字母": "小文字 1 字",
+    "形如 name.slice": "name.slice の形式",
+    "来源：{v}": "由来：{v}",
+    "格式：{v}": "形式：{v}",
+    "环境变量：{v}": "環境変数：{v}",
+    "界面语言：{lang}（来自 {source}；ATM_LANG=zh|en|ja 可强制）": "表示言語：{lang}（{source} より；ATM_LANG=zh|en|ja で強制）",
+    "非负整数": "非負の整数",
+    "默认：{v}": "デフォルト：{v}",
 }
 
 CATALOG: dict[str, dict[str, str]] = {"en": EN, "ja": JA}

--- a/tests/test_config_tui.py
+++ b/tests/test_config_tui.py
@@ -254,3 +254,87 @@ def test_draw_scrolls_to_keep_cursor_visible() -> None:
     ed._draw(win)
     assert any("tmux.renumber-windows" in t for t in win.lines.values())
     assert not any("memory.enabled" in t for t in win.lines.values())
+
+
+# ---------------------------------------------------------------- 右侧说明面板
+
+
+class RecWin:
+    """记录 (y, x, text) 的假窗口。"""
+
+    def __init__(self, height: int, width: int) -> None:
+        self._size = (height, width)
+        self.cells: list[tuple[int, int, str]] = []
+
+    def getmaxyx(self) -> tuple[int, int]:
+        return self._size
+
+    def erase(self) -> None:
+        self.cells.clear()
+
+    def refresh(self) -> None:
+        pass
+
+    def addstr(self, y: int, x: int, text: str, attr: int = 0) -> None:
+        self.cells.append((y, x, text))
+
+
+def test_panel_x_threshold() -> None:
+    assert ConfigEditor.panel_x(80) is None
+    assert ConfigEditor.panel_x(90) == 52
+    assert ConfigEditor.panel_x(140) == 77
+
+
+def test_panel_lines_describe_selected_key_in_current_language(monkeypatch) -> None:
+    from atm import i18n
+
+    sources = {**dict.fromkeys(config.KEYS, "default"), "memory.high": "env ATM_MEMORY_HIGH"}
+    ed = editor(config.Config(), sources)
+    row = ed._rows[row_index("memory.high")]
+    zh = ed.panel_lines(row, 60)
+    assert zh[0] == "memory.high"
+    assert any("软上限" in ln for ln in zh)
+    assert any("格式：" in ln and "4G" in ln for ln in zh)
+    assert any("默认：2G" in ln for ln in zh)
+    assert any("环境变量：ATM_MEMORY_HIGH" in ln for ln in zh)
+    assert any("来源：env ATM_MEMORY_HIGH" in ln for ln in zh)
+    assert any(ln.startswith("⚠") for ln in zh)
+    assert any("界面语言：zh" in ln for ln in zh)
+
+    monkeypatch.setenv("ATM_LANG", "en")
+    i18n.reset_lang()
+    try:
+        en = ed.panel_lines(row, 60)
+        assert any("soft cap" in ln for ln in en)
+        assert any("UI language: en" in ln and "ATM_LANG" in ln for ln in en)
+        assert not any("软上限" in ln for ln in en)
+    finally:
+        monkeypatch.delenv("ATM_LANG")
+        i18n.reset_lang()
+
+
+def test_wide_terminal_draws_panel_and_clips_rows() -> None:
+    ed = editor(config.Config(), {**dict.fromkeys(config.KEYS, "default"), "memory.slice": "file"})
+    win = RecWin(30, 120)
+    ed._draw(win)
+    px = ConfigEditor.panel_x(120)
+    right = [c for c in win.cells if c[1] >= px]
+    assert any("memory.enabled" in t for _y, _x, t in right)  # 面板第一行是键名
+    assert any("要不要套闸门" in t for _y, _x, t in right)  # 说明在面板里
+    assert any(t.startswith("┌") for _y, _x, t in right)
+    # 列表区的文字都在面板左边结束
+    for y, x, t in win.cells:
+        if 3 <= y < 27 and x < px:
+            from atm.text import display_width
+
+            assert x + display_width(t) <= px, (y, x, t)
+    # 底部那行不再重复说明
+    assert not any(y == 27 and "要不要套闸门" in t for y, _x, t in win.cells)
+
+
+def test_narrow_terminal_falls_back_to_bottom_line() -> None:
+    ed = editor()
+    win = RecWin(24, 70)
+    ed._draw(win)
+    assert not any(t.startswith("┌") for _y, _x, t in win.cells)
+    assert any(y == 21 and x == 0 and "要不要套闸门" in t for y, x, t in win.cells)

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -145,3 +145,17 @@ def test_all_catalog_entries_format_without_error() -> None:
             names = {m.strip("{}").split("!")[0].split(":")[0] for m in PLACEHOLDER.findall(key)}
             kwargs = {n: Any() for n in names if n}
             value.format(**kwargs)
+
+
+def test_lang_source_names_the_deciding_variable(monkeypatch) -> None:
+    monkeypatch.setenv("ATM_LANG", "ja")
+    i18n.reset_lang()
+    assert (i18n.lang(), i18n.lang_source()) == ("ja", "ATM_LANG")
+    monkeypatch.delenv("ATM_LANG")
+    monkeypatch.setenv("LC_ALL", "zh_CN.UTF-8")
+    i18n.reset_lang()
+    assert (i18n.lang(), i18n.lang_source()) == ("zh", "LC_ALL")
+    monkeypatch.delenv("LC_ALL")
+    monkeypatch.setenv("LANG", "C.UTF-8")
+    i18n.reset_lang()
+    assert (i18n.lang(), i18n.lang_source()) == ("en", "LANG")


### PR DESCRIPTION
## Motivation

The `atm config` editor left the right half of the screen empty and squeezed the selected key's help into one bottom line. With 17 keys there is more to say per key than fits there: what values it accepts, the default, the env var that overrides it, and where the current value came from. And because the UI is trilingual, the panel should also tell the user which variable picked the language.

## Summary of changes

- `config_tui.py`: `panel_x(width)` (panel at ≥ 90 columns, list keeps ≥ 52), `format_hint(key)` (one line per validation rule in `config._coerce`), `panel_lines(row, width)` (key, description via `_()`, format, default, env var, source, env-override warning, UI language + source), `_draw_panel` with a border. Rows are clipped at the panel edge; the env-override note moves into the panel. Terminals narrower than 90 columns keep the old bottom line.
- `i18n.py`: `lang_source()` — `ATM_LANG` / `LC_ALL` / `LC_MESSAGES` / `LANG` / `locale` / `default`; detection refactored into `_detect_with_source()` (same rules).
- 14 EN/JA catalog rows. Docs: `docs/usage*.md` config line, `docs/reference.md` 配置 + 界面语言.

## How it was verified

- `uv run --frozen pytest`: 410 passed. New: panel threshold, panel contents in zh and en (translation switches, env warning, language source), wide draw (panel present, no row text crosses the panel edge, bottom line no longer duplicates), narrow draw (no panel, bottom line), `lang_source` for `ATM_LANG` / `LC_ALL` / `LANG=C`.
- `ruff check` / `ruff format --check` clean.
- Rendered in an isolated tmux server (`-L x -f /dev/null`): 130×28 English with `ATM_MEMORY_HIGH` set (panel shows the override warning and `UI language: en (from ATM_LANG)`), 76×22 Japanese (bottom-line fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
