### PR TITLE
chore: bump version to 0.6.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 # PyPI 上 `atm` 已被占用；发行名用全名，命令名仍是 `atm`。
 name = "ai-terminal-manager"
-version = "0.6.0"
+version = "0.6.1"
 description = "Multi-session manager for AI CLIs (Claude Code / Codex / Pi) inside tmux: unified history, resume into any pane, persistent sidebar"
 readme = "README.md"
 license = "MIT"

--- a/src/atm/__init__.py
+++ b/src/atm/__init__.py
@@ -9,6 +9,6 @@
 
 from .model import IndexStats, SessionEntry, SessionIndex, Source
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 
 __all__ = ["IndexStats", "SessionEntry", "SessionIndex", "Source", "__version__"]

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "ai-terminal-manager"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Motivation

Two changes since v0.6.0: #22 (`atm update` retries straight from PyPI when the index mirror lags) and #23 (config editor description panel + `i18n.lang_source()`). No CLI or config-format break → patch.

## Summary of changes

0.6.0 → 0.6.1 in `pyproject.toml`, `src/atm/__init__.py`, and the root package in `uv.lock` (hand-edited).

## How it was verified

ruff check / format clean; pytest 410 passed; `uv build` wheel = `atm/` + dist-info only, sdist has no `research/`; README links absolute. After merge: tag `v0.6.1` → publish workflow → PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
