### PR TITLE
chore: bump version to 0.6.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 # PyPI 上 `atm` 已被占用；发行名用全名，命令名仍是 `atm`。
 name = "ai-terminal-manager"
-version = "0.6.1"
+version = "0.6.2"
 description = "Multi-session manager for AI CLIs (Claude Code / Codex / Pi) inside tmux: unified history, resume into any pane, persistent sidebar"
 readme = "README.md"
 license = "MIT"

--- a/src/atm/__init__.py
+++ b/src/atm/__init__.py
@@ -9,6 +9,6 @@
 
 from .model import IndexStats, SessionEntry, SessionIndex, Source
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"
 
 __all__ = ["IndexStats", "SessionEntry", "SessionIndex", "Source", "__version__"]

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "ai-terminal-manager"
-version = "0.6.1"
+version = "0.6.2"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Motivation

#25 fixed nine correctness holes, two of which could lose data (an env override baked into `config.toml`, malformed markers truncating `~/.tmux.conf`). Bug fixes only → patch release.

## Summary of changes

0.6.1 → 0.6.2 in `pyproject.toml`, `src/atm/__init__.py`, and the root package in `uv.lock` (hand-edited).

## How it was verified

ruff check / format clean; pytest 452 passed; `uv build` wheel = `atm/` + dist-info only, sdist has no `research/`. After merge: tag `v0.6.2` → publish workflow → PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
