### PR TITLE
ci: auto-apply area/type labels on pull requests

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,90 @@
+# 自动打标签的规则（actions/labeler v5）。
+#
+# 只自动化「看文件就能确定」的两个维度：
+#   area:  改到了哪一块 —— 按路径判断，最可靠
+#   type:  哪一类改动   —— 按分支名前缀判断（本仓库约定 feat/ fix/ docs/ chore/ …）
+# priority: 和 status: 是人的判断，不自动加。
+#
+# 一个 PR 命中多条就会有多个标签，这是预期的：动了四个模块本来就该四个 area 都标上。
+
+"area: sources":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/atm/sources/**"
+          - "src/atm/jsonl.py"
+          - "src/atm/model.py"
+
+"area: tmux":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/atm/tmux.py"
+          - "src/atm/install.py"
+          - "src/atm/persist.py"
+          - "src/atm/tmuxopts.py"
+          - "src/atm/sidebar.py"
+          - "atm.tmux"
+
+"area: tui":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/atm/tui.py"
+          - "src/atm/sidebar_tui.py"
+          - "src/atm/config_tui.py"
+          - "src/atm/fuzzy.py"
+          - "src/atm/text.py"
+
+"area: config":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/atm/config.py"
+          - "src/atm/sync.py"
+          - "src/atm/guard.py"
+          - "src/atm/dispatch.py"
+
+"area: index":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/atm/index.py"
+          - "src/atm/cache.py"
+
+"area: packaging":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "pyproject.toml"
+          - "uv.lock"
+          - ".github/**"
+          - "src/atm/update.py"
+          - "src/atm/completion.py"
+
+"area: i18n":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/atm/i18n.py"
+          - "src/atm/i18n_catalog.py"
+
+# 只动文档 / 只动测试的 PR 直接定性，不用等分支名
+"type: docs":
+  - changed-files:
+      - all-globs-to-all-files:
+          - "**/*.md"
+
+"type: test":
+  - changed-files:
+      - all-globs-to-all-files:
+          - "tests/**"
+
+# 其余按分支名前缀。仓库约定见 AGENTS.md「Conventions」。
+"type: feat":
+  - head-branch: ["^feat/", "^feature/"]
+
+"type: fix":
+  - head-branch: ["^fix/", "^hotfix/"]
+
+"type: refactor":
+  - head-branch: ["^refactor/"]
+
+"type: perf":
+  - head-branch: ["^perf/"]
+
+"type: chore":
+  - head-branch: ["^chore/", "^release/", "^ci/", "^deps/"]

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,19 @@
+name: labeler
+
+# pull_request_target 而不是 pull_request：来自 fork 的 PR 用后者拿不到写权限，
+# 标签就打不上。这个 job **不检出代码**、只调官方 action，所以没有跑到 fork 代码的风险。
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          sync-labels: true # 文件改回去了就把对应标签摘掉


### PR DESCRIPTION
## Motivation

The repo now has a namespaced label set (`type:` / `area:` / `priority:` / `status:`). Two of those four dimensions can be decided by a machine, so they should not be manual work: which part of the codebase a PR touches, and what kind of change it is.

## Summary of changes

- `.github/labeler.yml` — 14 rules. `area:*` from changed paths, mapped onto the module boundaries in `src/atm` (sources, tmux, tui, config, index, packaging, i18n). `type:*` from the branch-name prefixes `AGENTS.md` already prescribes (`feat/`, `fix/`, `refactor/`, `perf/`, `chore/` + `release/`/`ci/`/`deps/`), plus two shortcuts: a PR whose files are all markdown gets `type: docs`, all-tests gets `type: test`.
- `.github/workflows/labeler.yml` — `actions/labeler@v5` on `pull_request_target` with `pull-requests: write`. `pull_request_target` is what lets labels land on PRs from forks; the job never checks out the head commit, so it does not execute fork code. `sync-labels: true` removes a label again when the matching files are reverted.

`priority:` and `status:` stay manual — they are judgement calls, not file paths.

## How it was verified

- Both files parsed with a real YAML parser: 14 rules, the expected `changed-files` / `head-branch` split, `permissions` limited to `contents: read` + `pull-requests: write`.
- **This PR cannot label itself.** `pull_request_target` loads the workflow from the *base* branch, and `main` does not have it yet. The first PR opened after this merges is the real check — expected there: `area:` from its paths, `type:` from its branch prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
